### PR TITLE
No longer a reparenting WM

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -1,7 +1,7 @@
 [testAction]
 key = "j"
-modifiers = [ "control", "shift" ]
+modifiers = [ "control" ]
 
-[testAction2]
-key = "k"
-modifiers = [ "control", "shift", "super" ]
+[destroySelectedWindow]
+key = "q"
+modifiers = [ "super", "shift" ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+nimble build || exit 1
+Xephyr -br -ac -reset -screen 800x600 :1 &
+sleep 1s
+export DISPLAY=:1
+sxhkd &
+./nimdow

--- a/src/nimdow.nim
+++ b/src/nimdow.nim
@@ -38,8 +38,6 @@ when isMainModule:
     SubstructureNotifyMask or
     ButtonPressMask or
     PointerMotionMask or
-    EnterWindowMask or
-    LeaveWindowMask or
     StructureNotifyMask or
     PropertyChangeMask or
     KeyPressMask or

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -5,58 +5,98 @@ import
   config/config,
   event/xeventmanager
 
+converter cUlongToCUint(x: culong): cuint = x.cuint
+converter intToCint(x: int): cint = x.cint
+converter intToCUint(x: int): cuint = x.cuint
+converter toTBool(x: bool): TBool = x.TBool
+converter toBool(x: TBool): bool = x.bool
+
+const borderColorFocused = 0x3355BB
+const borderColorUnfocused = 0x335544
+const borderWidth = 2
+
 type
-  Frame = TWindow
   WindowManager* = ref object
     display: PDisplay
     rootWindow: TWindow
-    frameMap: Table[TWindow, Frame]
 
 proc configureConfigActions*(this: WindowManager)
-proc frameWindow(this: WindowManager, window: TWindow)
 # Custom WM actions
-proc testAction*()
-proc testAction2*()
+proc testAction*(this: WindowManager)
+proc destroySelectedWindow(this: WindowManager)
 # XEvent handlers
+proc errorHandler(disp: PDisplay, error: PXErrorEvent): cint{.cdecl.}
 proc onCreateNotify(this: WindowManager, e: TXCreateWindowEvent)
 proc onConfigureRequest(this: WindowManager, e: TXConfigureRequestEvent)
 proc onMapRequest(this: WindowManager, e: TXMapRequestEvent)
-proc onUnmapNotify(this: WindowManager, e: TXUnmapEvent)
-proc onDestroyNotify(this: WindowManager, e: TXDestroyWindowEvent)
+proc onEnterNotify(this: WindowManager, e: TXCrossingEvent)
+proc onFocusIn(this: WindowManager, e: TXFocusChangeEvent)
+proc onFocusOut(this: WindowManager, e: TXFocusChangeEvent)
 
 proc newWindowManager*(display: PDisplay, rootWindow: TWindow): WindowManager =
-  WindowManager(
-    display: display,
-    rootWindow: rootWindow,
-    frameMap: initTable[TWindow, TWindow]()
-  )
+  WindowManager(display: display, rootWindow: rootWindow)
 
 proc initWindowManager*(this: WindowManager, eventManager: XEventManager) =
+  discard XSetErrorHandler(errorHandler)
   # TODO: Can clean this up with a template probably
   eventManager.addListener((e: TXEvent) => onCreateNotify(this, e.xcreatewindow), CreateNotify)
   eventManager.addListener((e: TXEvent) => onConfigureRequest(this, e.xconfigurerequest), ConfigureRequest)
   eventManager.addListener((e: TXEvent) => onMapRequest(this, e.xmaprequest), MapRequest)
-  eventManager.addListener((e: TXEvent) => onUnmapNotify(this, e.xunmap), UnmapNotify)
-  eventManager.addListener((e: TXEvent) => onDestroyNotify(this, e.xdestroywindow), DestroyNotify)
+  eventManager.addListener((e: TXEvent) => onEnterNotify(this, e.xcrossing), EnterNotify)
+  eventManager.addListener((e: TXEvent) => onFocusIn(this, e.xfocus), FocusIn)
+  eventManager.addListener((e: TXEvent) => onFocusOut(this, e.xfocus), FocusOut)
+
+  # Grab key combos defined in the user's config
+  for keyCombo in config.ConfigTable.keys():
+    discard XGrabKey(
+      this.display,
+      keyCombo.keycode,
+      keyCombo.modifiers,
+      this.rootWindow,
+      true,
+      GrabModeAsync,
+      GrabModeAsync
+    )
 
 proc configureConfigActions*(this: WindowManager) =
   ## Maps available user configuration options to window manager actions.
-  config.configureAction("testAction", testAction)
-  config.configureAction("testAction2", testAction2)
+  config.configureAction("testAction", () => testAction(this))
+  config.configureAction("destroySelectedWindow", () => destroySelectedWindow(this))
 
-proc testAction*() =
-  echo "I did a thing with the windows"
+proc testAction*(this: WindowManager) =
+  var selectedWin: TWindow
+  var selectionState: cint
+  discard XGetInputFocus(this.display, addr(selectedWin), addr(selectionState))
+  echo "Selected win: ", selectedWin
+  echo "Selection state: ", selectionState
 
-proc testAction2*() =
-  echo "I did a ANOTHER thing with the windows"
+proc destroySelectedWindow(this: WindowManager) =
+  var selectedWin: TWindow
+  var selectionState: cint
+  discard XGetInputFocus(this.display, addr(selectedWin), addr(selectionState))
+  var event = TXEvent()
+  event.xclient.theType = ClientMessage
+  event.xclient.window = selectedWin
+  event.xclient.message_type = XInternAtom(this.display, "WM_PROTOCOLS", true)
+  event.xclient.format = 32
+  event.xclient.data.l[0] = XInternAtom(this.display, "WM_DELETE_WINDOW", false).cint
+  event.xclient.data.l[1] = CurrentTime
+  discard XSendEvent(this.display, selectedWin, false, NoEventMask, addr(event))
+
+proc errorHandler(disp: PDisplay, error: PXErrorEvent): cint{.cdecl.} =
+  echo "Error: ", error.theType
 
 proc onCreateNotify(this: WindowManager, e: TXCreateWindowEvent) =
-  # TODO: Evaluate a better way to do this.
-  for val in this.frameMap.values:
-    if val == e.window:
-      return
-  this.frameMap[e.window] = e.window
-  this.frameWindow(e.window)
+  discard XSetWindowBorderWidth(this.display, e.window, borderWidth)
+  discard XSetWindowBorder(this.display, e.window, borderColorUnfocused)
+  discard XSelectInput(
+    this.display,
+    e.window,
+    SubstructureRedirectMask or
+    SubstructureNotifyMask or
+    EnterWindowMask or
+    FocusChangeMask
+  )
 
 proc onConfigureRequest(this: WindowManager, e: TXConfigureRequestEvent) =
   # Pass config defaults down (for now)
@@ -68,63 +108,17 @@ proc onConfigureRequest(this: WindowManager, e: TXConfigureRequestEvent) =
   changes.border_width = e.border_width
   changes.sibling = e.above
   changes.stack_mode = e.detail
-
-  discard XConfigureWindow(
-    this.display,
-    e.window,
-    cuint(e.value_mask),
-    addr(changes)
-  )
-
-  if this.frameMap.hasKey(e.window):
-    let frame = this.frameMap[e.window]
-    discard XConfigureWindow(this.display, frame, cuint(e.value_mask), addr(changes))
+  discard XConfigureWindow(this.display, e.window, e.value_mask, addr(changes))
 
 proc onMapRequest(this: WindowManager, e: TXMapRequestEvent) =
-  if this.frameMap.hasKey(e.window):
-    discard XMapWindow(this.display, this.frameMap[e.window])
-    discard XMapWindow(this.display, e.window)
+  discard XMapWindow(this.display, e.window)
 
-proc frameWindow(this: WindowManager, window: TWindow) =
-  ## Creates a parent window that encapsulates the given window.
-  ## This new frame window is a direct child of the root window.
-  ## The given window becomes a direct child of the new frame.
-  # TODO: We need to set up window border properties with the config file
-  let borderWidth = 2
-  let borderColor = 0x3355BB
-  let backgroundColor = 0x333333
-  var windowAttr: TXWindowAttributes
-  discard XGetWindowAttributes(this.display, window, addr(windowAttr))
-  let frame: Frame = XCreateSimpleWindow(
-    this.display,
-    this.rootWindow,
-    windowAttr.x,
-    windowAttr.y,
-    cuint(windowAttr.width),
-    cuint(windowAttr.height),
-    cuint(borderWidth),
-    culong(borderColor),
-    culong(backgroundColor)
-  )
-  discard XSelectInput(
-    this.display,
-    frame,
-    SubstructureRedirectMask or SubstructureNotifyMask
-  )
-  discard XAddToSaveSet(this.display, window)
-  discard XReparentWindow(this.display, window, frame, 0, 0)
-  this.frameMap[window] = frame
+proc onEnterNotify(this: WindowManager, e: TXCrossingEvent) =
+  discard XSetInputFocus(this.display, e.window, RevertToNone, CurrentTime)
 
-proc onUnmapNotify(this: WindowManager, e: TXUnmapEvent) =
-  if this.frameMap.hasKey(e.window):
-    let frame = this.frameMap[e.window]
-    discard XUnmapWindow(this.display, frame)
+proc onFocusIn(this: WindowManager, e: TXFocusChangeEvent) =
+  discard XSetWindowBorder(this.display, e.window, borderColorFocused)
 
-proc onDestroyNotify(this: WindowManager, e: TXDestroyWindowEvent) =
-  if not this.frameMap.hasKey(e.window):
-    # Return early if we are not tracking the window (usually our frame windows)
-    return
-  let frame: Frame = this.frameMap[e.window]
-  discard XDestroyWindow(this.display, frame)
-  this.frameMap.del(e.window)
+proc onFocusOut(this: WindowManager, e: TXFocusChangeEvent) =
+  discard XSetWindowBorder(this.display, e.window, borderColorUnfocused)
 


### PR DESCRIPTION
## What changed
- Removed parent frames from windows
- Added an error handler (just echoes the error type)
- Border colors are now rendered based on focus

## Rationale
Nimdow never planned to have window decorations - removing the extra parent frames makes the code a lot simpler to deal with.