### PR TITLE
Implemented masterstack layout

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 nimble build || exit 1
-Xephyr -br -ac -reset -screen 800x600 :1 &
+Xephyr -br -ac -reset -screen 1920x1080 :1 &
 sleep 1s
 export DISPLAY=:1
 sxhkd &

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -1,0 +1,12 @@
+import
+  x11 / [x, xlib],
+  sets
+
+type Layout* = ref object of RootObj
+  name*: string
+  gapSize*: int
+  borderSize*: int
+
+method doLayout(this: Layout, display: PDisplay, windows: OrderedSet[TWindow]) {.base.} =
+  echo "Not implemented for base class"
+

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -7,6 +7,9 @@ type Layout* = ref object of RootObj
   gapSize*: int
   borderSize*: int
 
-method doLayout(this: Layout, display: PDisplay, windows: OrderedSet[TWindow]) {.base.} =
+proc newLayout*(name: string, gapSize: int, borderSize: int): Layout =
+  Layout(name: name, gapSize: gapSize, borderSize: borderSize)
+
+method doLayout*(this: Layout, display: PDisplay, windows: OrderedSet[TWindow]) {.base.} =
   echo "Not implemented for base class"
 

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -1,0 +1,60 @@
+import
+  x11 / [x, xlib],
+  sets,
+  math,
+  layout
+
+converter intToCint(x: int): cint = x.cint
+converter intToCUint(x: int): cuint = x.cuint
+converter cintToCUint(x: cint): cuint = x.cuint
+
+type MasterStackLayout* = ref object of Layout
+
+method doLayout*(this: MasterStackLayout, display: PDisplay, windows: OrderedSet[TWindow]) =
+  ## Aligns the windows in a master/stack fashion.
+  # TODO: This needs cleanup after the algorithm is refined
+  let screenWidth = XDisplayWidth(display, 0)
+  let screenHeight = XDisplayHeight(display, 0)
+  let windowCount = windows.len
+  if windowCount == 1:
+    for window in windows.items:
+      discard XMoveResizeWindow(
+        display,
+        window,
+        0,
+        0,
+        screenWidth,
+        screenHeight
+      )
+      # Hide border if it's the only window
+      discard XSetWindowBorderWidth(display, window, 0)
+  else:
+    let stackSize = windowCount - 1
+    let height = int(math.round((screenHeight - ((stackSize + 1) * this.gapSize)) / stackSize))
+    let roundingErr: int = screenHeight - (this.gapSize + (height + this.gapSize) * stackSize)
+    for (i, window) in windows.pairs():
+      discard XSetWindowBorderWidth(display, window, this.borderSize)
+      # Layout master/stack layout
+      if i == 0:
+        discard XMoveResizeWindow(
+          display,
+          window,
+          this.gapSize,
+          this.gapSize,
+          int(math.round(screenWidth / 2)) - (this.borderSize * 2) - int(math.round(float(this.gapSize) * 1.5)),
+          screenHeight - (this.gapSize + this.borderSize) * 2
+        )  
+      else:
+        var yPos = height * (i - 1) + this.gapSize * i
+        if i == stackSize:
+          echo "Adding rounding error on ", i, ": ", roundingErr
+          yPos += roundingErr
+        discard XMoveResizeWindow(
+          display,
+          window,
+          int(math.round(screenWidth / 2)) + int(math.round(this.gapSize / 2)),
+          yPos,
+          int(math.round(screenWidth / 2)) - (this.gapSize + this.borderSize) * 2,
+          height - this.borderSize * 2
+        )
+

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -10,11 +10,11 @@ converter intToCUint(x: int): cuint = x.cuint
 const layoutName: string = "masterstack"
 
 type MasterStackLayout* = ref object of Layout
-  masterSlots*: uint
+  masterSlots*: int
 
 proc layoutSingleWindow(
   display: PDisplay,
-  windows: OrderedSet[TWindow],
+  window: TWindow,
   screenWidth: int,
   screenHeight: int
 )
@@ -29,7 +29,7 @@ proc layoutMultipleWindows(
 proc newMasterStackLayout*(
   gapSize: int, 
   borderSize: int, 
-  masterSlots: uint
+  masterSlots: int
 ): MasterStackLayout =
   ## Creates a new MasterStack layout.
   ## masterSlots: The number of windows allowed on the left half of the screen (typically 1).
@@ -40,35 +40,46 @@ proc newMasterStackLayout*(
     masterSlots: masterSlots
   )
 
-method doLayout*(this: MasterStackLayout, display: PDisplay, windows: OrderedSet[TWindow]) =
+method doLayout*(
+    this: MasterStackLayout,
+    display: PDisplay,
+    windows: OrderedSet[TWindow]
+  ) =
   ## Aligns the windows in a master/stack fashion.
-  # TODO: This needs cleanup after the algorithm is refined
-  echo this.masterSlots
   let screenWidth = XDisplayWidth(display, 0)
   let screenHeight = XDisplayHeight(display, 0)
   let windowCount = windows.len
   if windowCount == 1:
-    layoutSingleWindow(display, windows, screenWidth, screenHeight)
+    for window in windows:
+      layoutSingleWindow(display, window, screenWidth, screenHeight)
   else:
     this.layoutMultipleWindows(display, windows, screenWidth, screenHeight)
 
 proc layoutSingleWindow(
   display: PDisplay,
-  windows: OrderedSet[TWindow],
+  window: TWindow,
   screenWidth: int,
   screenHeight: int
   ) =
-  for window in windows.items:
-    discard XMoveResizeWindow(
-      display,
-      window,
-      0,
-      0,
-      screenWidth,
-      screenHeight
-    )
-    # Hide border if it's the only window
-    discard XSetWindowBorderWidth(display, window, 0)
+  discard XMoveResizeWindow(
+    display,
+    window,
+    0,
+    0,
+    screenWidth,
+    screenHeight
+  )
+  # Hide border if it's the only window
+  discard XSetWindowBorderWidth(display, window, 0)
+
+proc max(x, y: int): int =
+  if x > y: x else: y
+
+proc calculateWindowHeight(this: MasterStackLayout, windowsInColumn: int, screenHeight: int): int =
+  if windowsInColumn <= 0: 0 else:
+    math.round(
+      (screenHeight - (windowsInColumn * this.gapSize)) / windowsInColumn
+    ).int - (this.borderSize * 2)
 
 proc layoutMultipleWindows(
   this: MasterStackLayout,
@@ -76,40 +87,55 @@ proc layoutMultipleWindows(
   windows: OrderedSet[TWindow],
   screenWidth: int,
   screenHeight: int
-  ) =
+) =
   let windowCount = windows.len
-  let stackSize = windowCount - 1
-  let windowWidth = int(math.round(screenWidth / 2)) - (this.borderSize * 2) - int(math.round(float(this.gapSize) * 1.5))
-  let height = int(math.round((screenHeight - ((stackSize + 1) * this.gapSize)) / stackSize))
-  let roundingErr: int = screenHeight - (this.gapSize + (height + this.gapSize) * stackSize)
+  # Ensure stack size isn't negative
+  let stackSize = max(0, windowCount - this.masterSlots)
+  let windowWidth = int(math.round(screenWidth / 2)) -
+                    (this.borderSize * 2) -
+                    int(math.round(float(this.gapSize) * 1.5))
+
+  let masterWindowHeight = this.calculateWindowHeight(this.masterSlots, screenHeight)
+  let stackWindowHeight = this.calculateWindowHeight(stackSize, screenHeight)
+
+  # NOTE: We are getting rounding errors larger than 1. Offset per window?
+  # We also need to offset the master area.
+  let roundingErr: int = screenHeight - (this.gapSize + (stackWindowHeight + this.gapSize) * stackSize)
+  echo "Adding rounding error on ", stackSize, ": ", roundingErr
+
   for (i, window) in windows.pairs():
     discard XSetWindowBorderWidth(display, window, this.borderSize)
-    # Layout master/stack layout
-    # TODO: Handle multiple master windows.
-    # We can use the same algorithm for both, just change the X position
-    # based on i < (this.masterSlots - 1)
-    if i == 0:
+    if i < this.masterSlots:
+      # Master layout
+      let yPos = masterWindowHeight * i +
+                 (this.gapSize * i)
+
       # Layout left window
       discard XMoveResizeWindow(
         display,
         window,
         this.gapSize,
-        this.gapSize,
+        yPos,
         windowWidth,
-        screenHeight - (this.gapSize + this.borderSize) * 2
+        masterWindowHeight
       )  
     else:
-      var yPos = height * (i - 1) + this.gapSize * i
-      if i == stackSize:
-        echo "Adding rounding error on ", i, ": ", roundingErr
-        # NOTE: We are getting rounding errors larger than 1. Offset per window?
+      # Stack layout
+      let stackIndex = i - this.masterSlots
+      var
+        xPos = int(math.round(screenWidth / 2)) +
+               int(math.round(this.gapSize / 2))
+        yPos = stackWindowHeight * stackIndex +
+               (this.gapSize * stackIndex + 1)
+
+      if stackIndex == stackSize:
         yPos += roundingErr
       discard XMoveResizeWindow(
         display,
         window,
-        int(math.round(screenWidth / 2)) + int(math.round(this.gapSize / 2)),
+        xPos,
         yPos,
         windowWidth,
-        height - this.borderSize * 2
+        stackWindowHeight
       )
 

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -6,55 +6,110 @@ import
 
 converter intToCint(x: int): cint = x.cint
 converter intToCUint(x: int): cuint = x.cuint
-converter cintToCUint(x: cint): cuint = x.cuint
+
+const layoutName: string = "masterstack"
 
 type MasterStackLayout* = ref object of Layout
+  masterSlots*: uint
+
+proc layoutSingleWindow(
+  display: PDisplay,
+  windows: OrderedSet[TWindow],
+  screenWidth: int,
+  screenHeight: int
+)
+proc layoutMultipleWindows(
+  this: MasterStackLayout,
+  display: PDisplay,
+  windows: OrderedSet[TWindow],
+  screenWidth: int,
+  screenHeight: int
+)
+
+proc newMasterStackLayout*(
+  gapSize: int, 
+  borderSize: int, 
+  masterSlots: uint
+): MasterStackLayout =
+  ## Creates a new MasterStack layout.
+  ## masterSlots: The number of windows allowed on the left half of the screen (typically 1).
+  MasterStackLayout(
+    name: layoutName,
+    gapSize: gapSize,
+    borderSize: borderSize,
+    masterSlots: masterSlots
+  )
 
 method doLayout*(this: MasterStackLayout, display: PDisplay, windows: OrderedSet[TWindow]) =
   ## Aligns the windows in a master/stack fashion.
   # TODO: This needs cleanup after the algorithm is refined
+  echo this.masterSlots
   let screenWidth = XDisplayWidth(display, 0)
   let screenHeight = XDisplayHeight(display, 0)
   let windowCount = windows.len
   if windowCount == 1:
-    for window in windows.items:
+    layoutSingleWindow(display, windows, screenWidth, screenHeight)
+  else:
+    this.layoutMultipleWindows(display, windows, screenWidth, screenHeight)
+
+proc layoutSingleWindow(
+  display: PDisplay,
+  windows: OrderedSet[TWindow],
+  screenWidth: int,
+  screenHeight: int
+  ) =
+  for window in windows.items:
+    discard XMoveResizeWindow(
+      display,
+      window,
+      0,
+      0,
+      screenWidth,
+      screenHeight
+    )
+    # Hide border if it's the only window
+    discard XSetWindowBorderWidth(display, window, 0)
+
+proc layoutMultipleWindows(
+  this: MasterStackLayout,
+  display: PDisplay,
+  windows: OrderedSet[TWindow],
+  screenWidth: int,
+  screenHeight: int
+  ) =
+  let windowCount = windows.len
+  let stackSize = windowCount - 1
+  let windowWidth = int(math.round(screenWidth / 2)) - (this.borderSize * 2) - int(math.round(float(this.gapSize) * 1.5))
+  let height = int(math.round((screenHeight - ((stackSize + 1) * this.gapSize)) / stackSize))
+  let roundingErr: int = screenHeight - (this.gapSize + (height + this.gapSize) * stackSize)
+  for (i, window) in windows.pairs():
+    discard XSetWindowBorderWidth(display, window, this.borderSize)
+    # Layout master/stack layout
+    # TODO: Handle multiple master windows.
+    # We can use the same algorithm for both, just change the X position
+    # based on i < (this.masterSlots - 1)
+    if i == 0:
+      # Layout left window
       discard XMoveResizeWindow(
         display,
         window,
-        0,
-        0,
-        screenWidth,
-        screenHeight
+        this.gapSize,
+        this.gapSize,
+        windowWidth,
+        screenHeight - (this.gapSize + this.borderSize) * 2
+      )  
+    else:
+      var yPos = height * (i - 1) + this.gapSize * i
+      if i == stackSize:
+        echo "Adding rounding error on ", i, ": ", roundingErr
+        # NOTE: We are getting rounding errors larger than 1. Offset per window?
+        yPos += roundingErr
+      discard XMoveResizeWindow(
+        display,
+        window,
+        int(math.round(screenWidth / 2)) + int(math.round(this.gapSize / 2)),
+        yPos,
+        windowWidth,
+        height - this.borderSize * 2
       )
-      # Hide border if it's the only window
-      discard XSetWindowBorderWidth(display, window, 0)
-  else:
-    let stackSize = windowCount - 1
-    let height = int(math.round((screenHeight - ((stackSize + 1) * this.gapSize)) / stackSize))
-    let roundingErr: int = screenHeight - (this.gapSize + (height + this.gapSize) * stackSize)
-    for (i, window) in windows.pairs():
-      discard XSetWindowBorderWidth(display, window, this.borderSize)
-      # Layout master/stack layout
-      if i == 0:
-        discard XMoveResizeWindow(
-          display,
-          window,
-          this.gapSize,
-          this.gapSize,
-          int(math.round(screenWidth / 2)) - (this.borderSize * 2) - int(math.round(float(this.gapSize) * 1.5)),
-          screenHeight - (this.gapSize + this.borderSize) * 2
-        )  
-      else:
-        var yPos = height * (i - 1) + this.gapSize * i
-        if i == stackSize:
-          echo "Adding rounding error on ", i, ": ", roundingErr
-          yPos += roundingErr
-        discard XMoveResizeWindow(
-          display,
-          window,
-          int(math.round(screenWidth / 2)) + int(math.round(this.gapSize / 2)),
-          yPos,
-          int(math.round(screenWidth / 2)) - (this.gapSize + this.borderSize) * 2,
-          height - this.borderSize * 2
-        )
 

--- a/src/nimdowpkg/tag.nim
+++ b/src/nimdowpkg/tag.nim
@@ -6,5 +6,8 @@ type Tag* = ref object
   id*: int
   layout*: Layout
 
+proc newTag*(id: int, layout: Layout): Tag =
+  Tag(id: id, layout: layout)
+
 proc hash*(this: Tag): Hash = !$Hash(this.id) 
 

--- a/src/nimdowpkg/tag.nim
+++ b/src/nimdowpkg/tag.nim
@@ -1,0 +1,10 @@
+import
+  hashes,
+  layouts/layout
+
+type Tag* = ref object
+  id*: int
+  layout*: Layout
+
+proc hash*(this: Tag): Hash = !$Hash(this.id) 
+

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -47,8 +47,8 @@ proc newWindowManager*(eventManager: XEventManager): WindowManager =
       id = i,
       layout = newMasterStackLayout(
         gapSize = 48,
-        borderSize = 2,
-        masterSlots = 2
+        borderSize = 12,
+        masterSlots = 1
       )
     )
     result.tagTable[tag] = initOrderedSet[TWindow]()

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -7,6 +7,7 @@ import
   config/config,
   event/xeventhandler,
   event/xeventmanager,
+  layouts/layout,
   layouts/masterstacklayout
 
 converter intToCint(x: int): cint = x.cint
@@ -42,9 +43,13 @@ proc newWindowManager*(eventManager: XEventManager): WindowManager =
 
   result.tagTable = OrderedTable[Tag, OrderedSet[TWindow]]()
   for i in 1..9:
-    let tag: Tag = Tag(
-      id: i,
-      layout: MasterStackLayout(name: "masterstack", gapSize: 48, borderSize: 2)
+    let tag: Tag = newTag(
+      id = i,
+      layout = newMasterStackLayout(
+        gapSize = 48,
+        borderSize = 2,
+        masterSlots = 1
+      )
     )
     result.tagTable[tag] = initOrderedSet[TWindow]()
 

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -47,7 +47,7 @@ proc newWindowManager*(eventManager: XEventManager): WindowManager =
       id = i,
       layout = newMasterStackLayout(
         gapSize = 48,
-        borderSize = 12,
+        borderSize = 2,
         masterSlots = 1
       )
     )

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1,11 +1,16 @@
 import
   sugar,
   tables,
+  sets,
   x11 / [x, xlib],
+  tag,
   config/config,
   event/xeventhandler,
-  event/xeventmanager
+  event/xeventmanager,
+  layouts/masterstacklayout
 
+converter intToCint(x: int): cint = x.cint
+converter intToCUint(x: int): cuint = x.cuint
 converter toTBool(x: bool): TBool = x.TBool
 converter toBool(x: TBool): bool = x.bool
 
@@ -14,10 +19,16 @@ type
     display*: PDisplay
     rootWindow*: TWindow
     xEventHandler: XEventHandler
+    tagTable: OrderedTable[Tag, OrderedSet[TWindow]]
+    selectedTag: Tag
 
 proc openDisplay(this: WindowManager): PDisplay
 proc configureConfigActions*(this: WindowManager)
 proc configureRootWindow(this: WindowManager): TWindow
+proc configureWindowMappingListeners(this: WindowManager, eventManager: XEventManager)
+proc addWindowToSelectedTags(this: WindowManager, e: TXMapEvent)
+proc removeWindowFromTagTable(this: WindowManager, e: TXUnmapEvent)
+proc layout(this: WindowManager)
 # Custom WM actions
 proc testAction*(this: WindowManager)
 proc destroySelectedWindow(this: WindowManager)
@@ -28,6 +39,43 @@ proc newWindowManager*(eventManager: XEventManager): WindowManager =
   result.rootWindow = result.configureRootWindow()
   result.xEventHandler = newXEventHandler(result.display, result.rootWindow)
   result.xEventHandler.initXEventHandler(eventManager)
+
+  result.tagTable = OrderedTable[Tag, OrderedSet[TWindow]]()
+  for i in 1..9:
+    let tag: Tag = Tag(
+      id: i,
+      layout: MasterStackLayout(name: "masterstack", gapSize: 48, borderSize: 2)
+    )
+    result.tagTable[tag] = initOrderedSet[TWindow]()
+
+  # View first tag by default
+  for tag in result.tagTable.keys():
+    result.selectedTag = tag
+    break
+  result.configureWindowMappingListeners(eventManager)
+
+proc configureWindowMappingListeners(this: WindowManager, eventManager: XEventManager) =
+  eventManager.addListener((e: TXEvent) => addWindowToSelectedTags(this, e.xmap), MapNotify)
+  eventManager.addListener((e: TXEvent) => removeWindowFromTagTable(this, e.xunmap), UnmapNotify)
+
+proc addWindowToSelectedTags(this: WindowManager, e: TXMapEvent) =
+  this.tagTable[this.selectedTag].incl(e.window)
+  this.layout()
+
+proc removeWindowFromTagTable(this: WindowManager, e: TXUnmapEvent) =
+  let numWindowsInSelectedTag = this.tagTable[this.selectedTag].len
+  for windows in this.tagTable.mvalues():
+    windows.excl(e.window)
+  # Check if the number of windows on the current tag has changed
+  if numWindowsInSelectedTag != this.tagTable[this.selectedTag].len:
+    this.layout()
+
+proc layout(this: WindowManager) =
+  ## Revalidates the current layout of the viewed tag(s).
+  this.selectedTag.layout.doLayout(
+    this.display,
+    this.tagTable[this.selectedTag]
+  )
 
 proc openDisplay(this: WindowManager): PDisplay =
   let tempDisplay = XOpenDisplay(nil)
@@ -50,7 +98,6 @@ proc configureRootWindow(this: WindowManager): TWindow =
     PropertyChangeMask or
     KeyPressMask or
     KeyReleaseMask
-
   # Listen for events on the root window
   discard XChangeWindowAttributes(
     this.display,
@@ -67,7 +114,11 @@ proc configureConfigActions*(this: WindowManager) =
 
 proc hookConfigKeys*(this: WindowManager) =
   this.xEventHandler.hookConfigKeys()
-  
+
+####################
+## Custom Actions ##
+####################
+
 proc testAction(this: WindowManager) =
   var selectedWin: TWindow
   var selectionState: cint

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -48,7 +48,7 @@ proc newWindowManager*(eventManager: XEventManager): WindowManager =
       layout = newMasterStackLayout(
         gapSize = 48,
         borderSize = 2,
-        masterSlots = 1
+        masterSlots = 2
       )
     )
     result.tagTable[tag] = initOrderedSet[TWindow]()


### PR DESCRIPTION
Closes #2 and #3

Note: In `masterstacklayout.nim` there is a proc called `calcRoundingErr`. This rounding error is created when the screen needs to be unevenly subdivided, e.g. 1080px divided by 7 will not come out to a whole number. We account for this rounding error by offsetting the last window in the relevant window stack by said rounding error.