### PR TITLE
Implemented fullscreen for applications

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -2,6 +2,10 @@
 key = "j"
 modifiers = [ "control" ]
 
+[toggleFullscreen]
+key = "f"
+modifiers = [ "super" ]
+
 [destroySelectedWindow]
 key = "q"
 modifiers = [ "super", "shift" ]

--- a/src/nimdowpkg/config/config.nim
+++ b/src/nimdowpkg/config/config.nim
@@ -56,10 +56,10 @@ proc loadConfigfile(configPath: string): TomlTable =
 
 proc populateAction(display: PDisplay, action: string, configTable: TomlTable) =
   let keyCombo = configTable.getKeyCombo(display, action)
-  if not ProcTable.hasKey(action):
-    raise newException(Exception, "Invalid key configuration: " &
-                       repr(action) & " not found")
-  ConfigTable[keyCombo] = ProcTable[action]
+  if ProcTable.hasKey(action):
+    ConfigTable[keyCombo] = ProcTable[action]
+  else:
+    echo "Invalid key config action: \"", action, "\" does not exist"
 
 proc getKeyCombo(configTable: TomlTable, display: PDisplay, action: string): KeyCombo =
   ## Gets the KeyCombo associated with the given `action` from the table.

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -378,7 +378,8 @@ proc onMapRequest(this: WindowManager, e: TXMapRequestEvent) =
     discard XMapWindow(this.display, e.window)
 
 proc onEnterNotify(this: WindowManager, e: TXCrossingEvent) =
-  discard XSetInputFocus(this.display, e.window, RevertToPointerRoot, CurrentTime)
+  if e.window != this.rootWindow:
+    discard XSetInputFocus(this.display, e.window, RevertToPointerRoot, CurrentTime)
 
 proc onFocusIn(this: WindowManager, e: TXFocusChangeEvent) =
   if e.window != this.rootWindow:

--- a/src/nimdowpkg/xatoms.nim
+++ b/src/nimdowpkg/xatoms.nim
@@ -4,20 +4,45 @@ import
 converter boolToTBool(x: bool): TBool = TBool(x)
 
 type
-  XAtomID* = enum
-    NetWMState, NetWMFullScreen, NetWMFullScreenAction
+  WMAtom* = enum
+    WMProtocols, WMDalete, WMState, WMTakeFocus, WMLast
+  NetAtom* = enum
+    NetActiveWindow, NetSupported,
+    NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
+    NetWMName, NetWMState, NetWMCheck, NetWMFullScreen,
+    NetWMWindowType, NetWMWindowTypeDialog, NetClientList, NetLast
+  XAtom* = enum
+    Manager, Xembed, XembedInfo, XLast
 
-proc createXAtoms*(display: PDisplay): array[3, TAtom] =
-  ## Creates an array of all atoms in order of the defined enum states in `XAtomID`
-  ##
-  ## ** Examples:**
-  ##
-  ##  .. code-block::
-  ##    let atoms = createAtoms(display)
-  ##    echo atoms[ord(XAtomID.NetWMFullScreen)]
+proc getWMAtoms*(display: PDisplay): array[ord(WMLast), TAtom] =
   [
+    XInternAtom(display, "WM_PROTOCOLS", false),
+    XInternAtom(display, "WM_DELETE_WINDOW", false),
+    XInternAtom(display, "WM_STATE", false),
+    XInternAtom(display, "WM_TAKE_FOCUS", false)
+  ]
+
+proc getNetAtoms*(display: PDisplay): array[ord(NetLast), TAtom] =
+  [
+    XInternAtom(display, "_NET_ACTIVE_WINDOW", false),
+    XInternAtom(display, "_NET_SUPPORTED", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_S0", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_OPCODE", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", false),
+    XInternAtom(display, "_NET_WM_NAME", false),
     XInternAtom(display, "_NET_WM_STATE", false),
+    XInternAtom(display, "_NET_SUPPORTING_WM_CHECK", false),
     XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", false),
-    XInternAtom(display, "_NET_WM_ACTION_FULLSCREEN", false)
+    XInternAtom(display, "_NET_WM_WINDOW_TYPE", false),
+    XInternAtom(display, "_NET_WM_WINDOW_TYPE_DIALOG", false),
+    XInternAtom(display, "_NET_CLIENT_LIST", false)
+  ]
+
+proc getXAtoms*(display: PDisplay): array[ord(XLast), TAtom] =
+  [
+    XInternAtom(display, "MANAGER", false),
+    XInternAtom(display, "_XEMBED", false),
+    XInternAtom(display, "_XEMBED_INFO", false)
   ]
 

--- a/src/nimdowpkg/xatoms.nim
+++ b/src/nimdowpkg/xatoms.nim
@@ -1,0 +1,22 @@
+import
+  x11 / [x, xlib]
+
+converter boolToTBool(x: bool): TBool = TBool(x)
+
+type
+  XAtomID* = enum
+    NetWMState, NetWMFullScreen
+
+proc createXAtoms*(display: PDisplay): array[2, TAtom] =
+  ## Creates an array of all atoms in order of the defined enum states in `XAtomID`
+  ##
+  ## ** Examples:**
+  ##
+  ##  .. code-block::
+  ##    let atoms = createAtoms(display)
+  ##    echo atoms[ord(XAtomID.NetWMFullScreen)]
+  [
+    XInternAtom(display, "_NET_WM_STATE", false),
+    XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", false)
+  ]
+

--- a/src/nimdowpkg/xatoms.nim
+++ b/src/nimdowpkg/xatoms.nim
@@ -5,9 +5,9 @@ converter boolToTBool(x: bool): TBool = TBool(x)
 
 type
   XAtomID* = enum
-    NetWMState, NetWMFullScreen
+    NetWMState, NetWMFullScreen, NetWMFullScreenAction
 
-proc createXAtoms*(display: PDisplay): array[2, TAtom] =
+proc createXAtoms*(display: PDisplay): array[3, TAtom] =
   ## Creates an array of all atoms in order of the defined enum states in `XAtomID`
   ##
   ## ** Examples:**
@@ -17,6 +17,7 @@ proc createXAtoms*(display: PDisplay): array[2, TAtom] =
   ##    echo atoms[ord(XAtomID.NetWMFullScreen)]
   [
     XInternAtom(display, "_NET_WM_STATE", false),
-    XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", false)
+    XInternAtom(display, "_NET_WM_STATE_FULLSCREEN", false),
+    XInternAtom(display, "_NET_WM_ACTION_FULLSCREEN", false)
   ]
 


### PR DESCRIPTION
Closes #12 

1. Windows requesting to be full-screened will now be full-screened. Applications tested:
  - Qutebrowser
  - Firefox
  - Vivaldi
  - Gimp

2. Windows can now be manually full-screened (using mod+f)

**Notes:**
- Implemented a number of Atoms
- Fixed a few small bugs that caused crashes and X errors
- Minor cleanup in a couple classes
- Non-existent key configurations declared in the config file will no longer crash Nimdow