### PR TITLE
Client (window) order can now be changed inside a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ I am using this project to learn Nim, x11, and to replace my build of **dwm** (w
   - [ ] Switch layout to monocle
   - [x] Navigate windows
   - [x] Navigate tags
+  - [ ] Move windows in stack
   - [ ] Move windows between tags
-
+  - [ ] Add/remove window per tag
 
 ## Version 1.0
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ I am using this project to learn Nim, x11, and to replace my build of **dwm** (w
   - [ ] Switch layout to monocle
   - [x] Navigate windows
   - [x] Navigate tags
-  - [ ] Move windows in stack
+  - [x] Move windows in stack
   - [ ] Move windows between tags
   - [ ] Add/remove window per tag
 

--- a/config.default.toml
+++ b/config.default.toml
@@ -8,6 +8,14 @@ modifiers = [ "super" ]
 keys = [ "j" ]
 modifiers = [ "super" ]
 
+[moveWindowPrevious]
+keys = [ "k" ]
+modifiers = [ "super", "shift" ]
+
+[moveWindowNext]
+keys = [ "j" ]
+modifiers = [ "super", "shift" ]
+
 [toggleFullscreen]
 keys = [ "f" ]
 modifiers = [ "super" ]

--- a/src/nimdowpkg/client.nim
+++ b/src/nimdowpkg/client.nim
@@ -1,6 +1,5 @@
 import
   x11/x,
-  sets,
   options,
   hashes
 
@@ -12,10 +11,10 @@ type
 proc newClient*(window: TWindow): Client =
   Client(window: window, isFullscreen: false)
 
-func find*(clients: OrderedSet[Client], window: TWindow): Option[Client] =
-  for client in clients:
+func indexOf*(clients: seq[Client], window: TWindow): int =
+  for i, client in clients:
     if client.window == window:
-      return some(client)
-  return none(Client)
+      return i
+  return -1
 
 proc hash*(this: Client): Hash = !$Hash(this.window) 

--- a/src/nimdowpkg/client.nim
+++ b/src/nimdowpkg/client.nim
@@ -1,6 +1,5 @@
 import
   x11/x,
-  options,
   hashes
 
 type
@@ -11,7 +10,7 @@ type
 proc newClient*(window: TWindow): Client =
   Client(window: window, isFullscreen: false)
 
-func indexOf*(clients: seq[Client], window: TWindow): int =
+func find*(clients: seq[Client], window: TWindow): int =
   for i, client in clients:
     if client.window == window:
       return i

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -11,6 +11,6 @@ type Layout* = ref object of RootObj
 proc newLayout*(name: string, gapSize: int, borderSize: int): Layout =
   Layout(name: name, gapSize: gapSize, borderSize: borderSize)
 
-method arrange*(this: Layout, display: PDisplay, clients: OrderedSet[Client]) {.base.} =
+method arrange*(this: Layout, display: PDisplay, clients: seq[Client]) {.base.} =
   echo "Not implemented for base class"
 

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -1,6 +1,5 @@
 import
   x11/xlib,
-  sets,
   math,
   layout,
   "../client"
@@ -22,7 +21,7 @@ proc layoutSingleClient(
 proc layoutMultipleClients(
   this: MasterStackLayout,
   display: PDisplay,
-  clients: OrderedSet[Client],
+  clients: seq[Client],
   screenWidth: int,
   screenHeight: int
 )
@@ -38,7 +37,7 @@ proc calcYPosition(
   roundingError: int
 ): int
 proc calcClientWidth(this: MasterStackLayout, screenWidth: int): int
-proc getClientsToBeArranged(clients: OrderedSet[Client]): OrderedSet[Client]
+proc getClientsToBeArranged(clients: seq[Client]): seq[Client]
 
 proc newMasterStackLayout*(
   gapSize: int, 
@@ -57,7 +56,7 @@ proc newMasterStackLayout*(
 method arrange*(
     this: MasterStackLayout,
     display: PDisplay,
-    clients: OrderedSet[Client]
+    clients: seq[Client]
   ) =
   ## Aligns the clients in a master/stack fashion.
   let screenWidth = XDisplayWidth(display, 0)
@@ -90,7 +89,7 @@ proc layoutSingleClient(
 proc layoutMultipleClients(
   this: MasterStackLayout,
   display: PDisplay,
-  clients: OrderedSet[Client],
+  clients: seq[Client],
   screenWidth: int,
   screenHeight: int
 ) =
@@ -178,10 +177,10 @@ proc calcClientWidth(this: MasterStackLayout, screenWidth: int): int =
     (this.borderSize * 2) -
     int(math.round(float(this.gapSize) * 1.5))
 
-proc getClientsToBeArranged(clients: OrderedSet[Client]): OrderedSet[Client] =
+proc getClientsToBeArranged(clients: seq[Client]): seq[Client] =
   ## Finds all clients that should be arranged in the layout.
   ## Some windows are excluded, such as fullscreen windows.
   for client in clients:
     if not client.isFullscreen:
-      result.incl(client)
+      result.add(client)
 


### PR DESCRIPTION
`moveWindowPrevious`: Moves a window to the previous position in the layout
Default: `super` + `shift` + `k`

`moveWindowNext`: Moves a window to the next position in the layout
Default: `super` + `shift` + `j`