### PR TITLE
User config file is loaded dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ I am using this project to learn Nim, x11, and to replace my build of **dwm** (w
 
 ## Running locally
 
+0. Create a copy or symlink of the config file in `$XDG_CONFIG_HOME/nimdow/config.toml`
 1. Start up Xephyr: `Xephyr -ac -screen 1920x1080 -br -reset -terminate 2> /dev/null :1 &`
 2. Execute nimdow on the new display: `DISPLAY=:1 ./nimdow`
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+config="${XDG_CONFIG_HOME}/nimdow/config.toml"
+if [ ! -f "$config" ]; then
+  mkdir -p "${XDG_CONFIG_HOME}/nimdow"
+  ln -s "$(pwd)/config.default.toml" "$config"
+  printf "Created symlink to %s\n" "$config"
+fi
+
 nimble build || exit 1
 Xephyr -br -ac -reset -screen 1920x1080 :1 &
 sleep 1s

--- a/src/nimdowpkg/config/config.nim
+++ b/src/nimdowpkg/config/config.nim
@@ -1,7 +1,8 @@
 import 
-  x11 / [x,  xlib],
+  os,
   parsetoml,
   tables,
+  x11 / [x,  xlib],
   "../keys/keyutils",
   "../event/xeventmanager"
 
@@ -43,9 +44,18 @@ proc populateConfigTable*(display: PDisplay) =
   for action in configTable.keys():
     display.populateAction(action, configTable)
 
+proc findDefaultConfig(): string =
+  echo "Using default config"
+  return absolutePath("config.default.toml")
+
 proc findConfigPath(): string =
-  # TODO: find this path dynamically
-  return "config.default.toml"
+  var configHome = os.getEnv("XDG_CONFIG_HOME")
+  if configHome.len > 0:
+    result = configHome & "/nimdow/config.toml"
+    if fileExists(result):
+      return result
+    echo "XDG_CONFIG_HOME not found"
+  result = findDefaultConfig()
 
 proc loadConfigfile(configPath: string): TomlTable =
   ## Reads the user's configuration file into a table.

--- a/src/nimdowpkg/config/config.nim
+++ b/src/nimdowpkg/config/config.nim
@@ -44,18 +44,11 @@ proc populateConfigTable*(display: PDisplay) =
   for action in configTable.keys():
     display.populateAction(action, configTable)
 
-proc findDefaultConfig(): string =
-  echo "Using default config"
-  return absolutePath("config.default.toml")
-
 proc findConfigPath(): string =
-  var configHome = os.getEnv("XDG_CONFIG_HOME")
-  if configHome.len > 0:
-    result = configHome & "/nimdow/config.toml"
-    if fileExists(result):
-      return result
-    echo "XDG_CONFIG_HOME not found"
-  result = findDefaultConfig()
+  let configHome = os.getConfigDir()
+  result = configHome & "nimdow/config.toml"
+  if not fileExists(result):
+    raise newException(Exception, result & " does not exist")
 
 proc loadConfigfile(configPath: string): TomlTable =
   ## Reads the user's configuration file into a table.


### PR DESCRIPTION
User config is loaded from `XDG_CONFIG_HOME` or `$HOME/.config` if the former is not defined.

Updated the README and `run.sh` to reflect the changes.

Related to #7 