### PR TITLE
Floating windows can be moved and resized.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ I am using this project to learn Nim, x11, and to replace my build of **dwm** (w
 
 If you are on an Arch Linux based system, use `nimdow-bin` in the AUR to install a pre-built binary.
 
+## Command line arguments
+
+Currently the only argument that may be provided is a config file path. This was added for testing purposes.
+
+E.g. `$ nimdow ./some-config.toml`
+
+If no argument is provided, we use the config file mentioned in the *Building from source* section.
+
 ## Polybar config
 
 If you would like to use Polybar with Nimdow, there is a config file [here](https://github.com/avahe-kellenberger/nimdow/tree/master/polybar).

--- a/config.default.toml
+++ b/config.default.toml
@@ -90,3 +90,7 @@ exec = [
   keys = [ "x" ]
   modifiers = [ "super" ]
 
+  [controls.toggleFloating]
+  keys = [ "space" ]
+  modifiers = [ "super" ]
+

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ Xephyr -br -ac -reset -screen 1920x1080 :1 &
 sleep 1s
 export DISPLAY=:1
 xrdb $HOME/.Xresources &
-./bin/nimdow &
+./bin/nimdow "./config.default.toml" &
 
 polybar -c ./polybar/nimdow nimdow &
 nm-applet &

--- a/src/nimdow.nim
+++ b/src/nimdow.nim
@@ -1,4 +1,5 @@
 import
+  os, 
   parsetoml,
   nimdowpkg/event/xeventmanager,
   nimdowpkg/windowmanager,
@@ -6,7 +7,16 @@ import
 
 when isMainModule:
   let loadedConfig = newConfig()
-  let configTable: TomlTable = configloader.loadConfigFile()
+  var configTable: TomlTable
+  
+  # If given a parameter for a config file, use it instead.
+  var configLoc: string
+  when declared(commandLineParams):
+    let params = commandLineParams()
+    if params.len == 1:
+      configLoc = params[0].string
+
+  configTable = configloader.loadConfigFile(configLoc)
   # General settings need to be populated before the windowmanager is created.
   loadedConfig.populateGeneralSettings(configTable)
 

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -78,7 +78,7 @@ proc getModifierMask(modifier: TomlValueRef): int =
                        repr(modifier) & " is not a a valid key modifier")
   return ModifierTable[modifier.stringVal]
 
-proc xorModifiers(modifiers: openarray[TomlValueRef]): int =
+proc bitorModifiers(modifiers: openarray[TomlValueRef]): int =
   for tomlElement in modifiers:
     result = result or getModifierMask(tomlElement)
 
@@ -186,9 +186,11 @@ proc findConfigPath(): string =
   if not fileExists(result):
     raise newException(Exception, result & " does not exist")
 
-proc loadConfigFile*(): TomlTable =
+proc loadConfigFile*(filePath: string = ""): TomlTable =
   ## Reads the user's configuration file into a table.
-  let configPath = findConfigPath()
+  ## If a filePath is given, that path will be used to load the config.
+  ## Otherwise, we find the user's configuration file.
+  let configPath = if filePath.len == 0: findConfigPath() else: filepath
   let loadedConfig = parsetoml.parseFile(configPath)
   if loadedConfig.kind != TomlValueKind.Table:
     raise newException(Exception, "Invalid config file!")
@@ -205,7 +207,7 @@ proc populateControlAction(this: Config, display: PDisplay, action: string, conf
 proc getKeyCombos(this: Config, configTable: TomlTable, display: PDisplay, action: string): seq[KeyCombo] =
   ## Gets the KeyCombos associated with the given `action` from the table.
   let modifierArray = this.getModifiersForAction(configTable, action)
-  let modifiers: int = xorModifiers(modifierArray)
+  let modifiers: int = bitorModifiers(modifierArray)
   let keys: seq[string] = this.getKeysForAction(configTable, action)
   for key in keys:
     let keycode: int = key.toKeycode(display)

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -88,16 +88,13 @@ proc layoutSingleClient(
   screenHeight: uint,
   offset: LayoutOffset
   ) =
-  discard XMoveResizeWindow(
-    display,
-    client.window,
-    this.monitorArea.x + offset.left.cint,
-    this.monitorArea.y + offset.top.cint,
-    screenWidth.cuint,
-    screenHeight.cuint
-  )
+  client.x = this.monitorArea.x + offset.left.int
+  client.y = this.monitorArea.y + offset.top.int
+  client.width = screenWidth
+  client.height = screenHeight
   # Hide border if it's the only client
-  discard XSetWindowBorderWidth(display, client.window, 0)
+  client.borderWidth = 0
+  client.adjustToState(display)
 
 proc layoutMultipleClients(
   this: MasterStackLayout,
@@ -130,7 +127,6 @@ proc layoutMultipleClients(
 
   for (i, client) in clients.pairs():
     var xPos, yPos, clientHeight: uint
-    discard XSetWindowBorderWidth(display, client.window, this.borderWidth.cuint)
     if i.uint < masterClientCount:
       # Master layout
       xPos = this.gapSize
@@ -143,14 +139,12 @@ proc layoutMultipleClients(
       yPos = this.calcYPosition(stackIndex, stackClientCount, stackClientHeight, stackRoundingErr)
       clientHeight = stackClientHeight
 
-    discard XMoveResizeWindow(
-      display,
-      client.window,
-      this.monitorArea.x + (xPos + offset.left).cint,
-      this.monitorArea.y + (yPos + offset.top).cint,
-      clientWidth.cuint,
-      clientHeight.cuint
-    )
+    client.x = this.monitorArea.x + (xPos + offset.left).int
+    client.y = this.monitorArea.y + (yPos + offset.top).int
+    client.width = clientWidth
+    client.height = clientHeight
+    client.borderWidth = this.borderWidth
+    client.adjustToState(display)
 
 proc calculateClientHeight(this: MasterStackLayout, clientsInColumn: uint, screenHeight: uint): uint =
   ## Calculates the height of a client (not counting its borders).

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -21,7 +21,6 @@ converter intToCUchar(x: int): cuchar = x.cuchar
 converter clongToCUlong(x: clong): culong = x.culong
 converter toTBool(x: bool): TBool = x.TBool
 
-# TODO: Should load these from settings
 const
   tagCount = 9
   masterSlots = 1
@@ -423,7 +422,11 @@ proc toggleFullscreen*(this: Monitor, client: var Client) =
       cast[Pcuchar]([]),
       0
     )
+    client.adjustToState(this.display)
   else:
+    # Don't invoke client.adjustToState here,
+    # since we want to be able to return the client to its normal state
+    # when/if this proc is invoked again.
     discard XSetWindowBorderWidth(this.display, client.window, 0)
     discard XMoveResizeWindow(
       this.display,
@@ -444,7 +447,6 @@ proc toggleFullscreen*(this: Monitor, client: var Client) =
       cast[Pcuchar](arr.addr),
       1
     )
-    discard XRaiseWindow(this.display, client.window)
 
   client.isFullscreen = not client.isFullscreen
   # Ensure the window has focus

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1,5 +1,6 @@
 import
   x11 / [x, xlib, xutil, xatom],
+  math,
   sugar,
   options,
   tables,
@@ -23,8 +24,11 @@ converter toBool(x: TBool): bool = x.bool
 const
   wmName = "nimdow"
   tagCount = 9
+  minimumUpdateInterval = math.round(1000 / 60).int
 
 type
+  MouseState* = enum
+    Normal, Moving, Resizing
   WindowManager* = ref object
     display*: PDisplay
     rootWindow*: TWindow
@@ -32,6 +36,10 @@ type
     config: Config
     monitors: seq[Monitor]
     selectedMonitor: Monitor
+    mouseState: MouseState
+    lastMousePress: tuple[x, y: int]
+    lastMoveResizeClientState: Area
+    lastMoveResizeTime: culong
 
 proc initListeners(this: WindowManager)
 proc openDisplay(): PDisplay
@@ -51,6 +59,10 @@ proc onMapRequest(this: WindowManager, e: TXMapRequestEvent)
 proc onMotionNotify(this: WindowManager, e: TXMotionEvent)
 proc onEnterNotify(this: WindowManager, e: TXCrossingEvent)
 proc onFocusIn(this: WindowManager, e: TXFocusChangeEvent)
+proc handleButtonPressed(this: WindowManager, e: TXButtonEvent)
+proc handleButtonReleased(this: WindowManager, e: TXButtonEvent)
+proc handleMouseMotion(this: WindowManager, e: TXMotionEvent)
+proc resize(this: WindowManager, client: Client, x, y: int, width, height: uint)
 
 proc newWindowManager*(eventManager: XEventManager, config: Config): WindowManager =
   result = WindowManager()
@@ -184,6 +196,9 @@ proc initListeners(this: WindowManager) =
         monitor.removeWindow(e.xdestroywindow.window),
       DestroyNotify
   )
+  this.eventManager.addListener((e: TXEvent) => handleButtonPressed(this, e.xbutton), ButtonPress)
+  this.eventManager.addListener((e: TXEvent) => handleButtonReleased(this, e.xbutton), ButtonRelease)
+  this.eventManager.addListener((e: TXEvent) => handleMouseMotion(this, e.xmotion), MotionNotify)
 
 proc openDisplay(): PDisplay =
   let tempDisplay = XOpenDisplay(nil)
@@ -245,16 +260,11 @@ proc moveClientToMonitor(this: WindowManager, monitorIndex: int) =
   if client.isFloating or client.isFullscreen:
     let deltaX = client.x - this.selectedMonitor.area.x
     let deltaY = client.y - this.selectedMonitor.area.y
-    client.x = nextMonitor.area.x + deltaX
-    client.y = nextMonitor.area.y + deltaY
-    discard XMoveResizeWindow(
-      this.display,
-      client.window,
-      client.x,
-      client.y,
-      client.width.cuint,
-      client.height.cuint
-    )
+    this.resize(client,
+                nextMonitor.area.x + deltaX,
+                nextMonitor.area.y + deltaY,
+                client.width,
+                client.height)
 
   nextMonitor.doLayout()
   this.selectedMonitor = nextMonitor
@@ -347,6 +357,21 @@ proc hookConfigKeys*(this: WindowManager) =
       GrabModeAsync
     )
 
+  # We only care about left and right clicks
+  for button in @[Button1, Button3]: 
+    discard XGrabButton(
+      this.display,
+      button,
+      Mod4Mask,
+      this.rootWindow,
+      false,
+      ButtonPressMask or ButtonReleaseMask or PointerMotionMask,
+      GrabModeASync,
+      GrabModeASync,
+      None,
+      None
+    )
+
 proc errorHandler(display: PDisplay, error: PXErrorEvent): cint{.cdecl.} =
   echo "Error: "
   var errorMessage: string = newString(1024)
@@ -354,7 +379,7 @@ proc errorHandler(display: PDisplay, error: PXErrorEvent): cint{.cdecl.} =
     display,
     cint(error.error_code),
     errorMessage.cstring,
-    len(errorMessage)
+    errorMessage.len
   )
   # Reduce string length down to the proper size
   errorMessage.setLen(errorMessage.cstring.len)
@@ -539,6 +564,10 @@ proc manage(this: WindowManager, window: TWindow, windowAttr: TXWindowAttributes
       return
 
   var client = newClient(window)
+  client.x = windowAttr.x
+  client.y = windowAttr.y
+  client.width = windowAttr.width.uint
+  client.height = windowAttr.height.uint
 
   discard XSetWindowBorder(this.display, window, this.config.borderColorUnfocused)
 
@@ -554,10 +583,10 @@ proc manage(this: WindowManager, window: TWindow, windowAttr: TXWindowAttributes
 
   discard XMoveResizeWindow(this.display,
                             window,
-                            windowAttr.x,
-                            windowAttr.y,
-                            windowAttr.width,
-                            windowAttr.height)
+                            client.x,
+                            client.y,
+                            client.width.cuint,
+                            client.height.cuint)
 
   this.updateWindowType(client)
   this.updateSizeHints(client)
@@ -610,13 +639,13 @@ proc onFocusIn(this: WindowManager, e: TXFocusChangeEvent) =
     e.window == this.rootWindow:
     return
 
-  let clientIndex = this.selectedMonitor.currTagClients.find(e.window)
-  if clientIndex < 0:
+  let clientOpt = this.selectedMonitor.find(e.window)
+  if clientOpt.isNone:
     return
   
   this.selectedMonitor.setActiveWindowProperty(e.window)
 
-  let client = this.selectedMonitor.currTagClients[clientIndex]
+  let client = clientOpt.get
   this.selectedMonitor.selectedTag.setSelectedClient(client)
   discard XSetWindowBorder(
     this.display,
@@ -631,4 +660,70 @@ proc onFocusIn(this: WindowManager, e: TXFocusChangeEvent) =
         previous.window,
         this.config.borderColorUnfocused
       )
+  discard XRaiseWindow(this.display, client.window)
+
+proc resize(this: WindowManager, client: Client, x, y: int, width, height: uint) =
+  ## Resizes and raises the client.
+  client.x = x
+  client.y = y
+  client.width = width
+  client.height = height
+  client.adjustToState(this.display)
+  discard XRaiseWindow(this.display, client.window)
+
+proc handleButtonPressed(this: WindowManager, e: TXButtonEvent) =
+  case e.button:
+    of Button1:
+      this.mouseState = MouseState.Moving
+    of Button3:
+      this.mouseState = MouseState.Resizing
+    else:
+      this.mouseState = MouseState.Normal
+
+  if this.mouseState != MouseState.Normal:
+    if this.selectedMonitor.currClient.isNone:
+      return
+    this.lastMousePress = (e.x.int, e.y.int)
+    let client = this.selectedMonitor.currClient.get
+    this.lastMoveResizeClientState = client.toArea()
+
+proc handleButtonReleased(this: WindowManager, e: TXButtonEvent) =
+  this.mouseState = MouseState.Normal
+
+proc handleMouseMotion(this: WindowManager, e: TXMotionEvent) =
+  if this.mouseState == Normal or this.selectedMonitor.currClient.isNone:
+    return
+
+  var client = this.selectedMonitor.currClient.get
+  if client.isFullscreen:
+    return
+
+  # Prevent trying to process events too quickly (causes major lag).
+  if e.time - this.lastMoveResizeTime < minimumUpdateInterval:
+    return
+
+  # Track the last time we moved or resized a window.
+  this.lastMoveResizeTime = e.time
+
+  if not client.isFloating:
+    client.isFloating = true
+    client.borderWidth = this.config.borderWidth.int
+    this.selectedMonitor.doLayout()
+
+  let
+    deltaX = e.x - this.lastMousePress.x
+    deltaY = e.y - this.lastMousePress.y
+  
+  if this.mouseState == Moving:
+    this.resize(client,
+                this.lastMoveResizeClientState.x + deltaX,
+                this.lastMoveResizeClientState.y + deltaY,
+                this.lastMoveResizeClientState.width,
+                this.lastMoveResizeClientState.height)
+  elif this.mouseState == Resizing:
+    this.resize(client,
+                this.lastMoveResizeClientState.x,
+                this.lastMoveResizeClientState.y,
+                this.lastMoveResizeClientState.width.int + deltaX,
+                this.lastMoveResizeClientState.height.int + deltaY)
 


### PR DESCRIPTION
- Added a keybinding to toggle the selected window's floating state
- Super + Left click moves windows (all except fixed or fullscreen windows)
- Super + Right click resizes windows (same as above)

A window's new monitor and tag are determined on button-release, using the center of the window to find the correct monitor.

I've also added an optional command line argument to provide an alternative config file (for testing).