### PR TITLE
Statusbar multihead fix

### DIFF
--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -278,6 +278,15 @@ proc removeWindowFromTagTable*(this: Monitor, window: Window): bool =
       this.removeWindowFromTag(tag, clientIndex) 
       result = true
 
+  if this.currTagClients.len == 0:
+    this.statusBar.setSelectedClient(nil, false)
+    this.statusBar.setActiveWindowTitle("")
+  else:
+    withSome(this.selectedTag.selectedClient, client):
+      this.statusBar.setSelectedClient(client)
+      withSome(this.display.getWindowName(client.window), title):
+        this.statusBar.setActiveWindowTitle(title)
+
 proc removeWindow*(this: Monitor, window: Window): bool =
   ## Returns if the window was removed.
   ## After a window is removed, you should typically call

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -713,12 +713,17 @@ proc handleButtonReleased(this: WindowManager, e: XButtonEvent) =
   let monitorIndex = this.monitors.find(centerX, centerY)
   if monitorIndex < 0 or this.monitors[monitorIndex] == this.selectedMonitor:
     return
-  let nextMonitor = this.monitors[monitorIndex]
-  let prevMonitor = this.selectedMonitor
+  let 
+    nextMonitor = this.monitors[monitorIndex]
+    prevMonitor = this.selectedMonitor
   # Remove client from current monitor/tag
   discard prevMonitor.removeWindow(client.window)
   nextMonitor.currTagClients.add(client)
   nextMonitor.selectedTag.setSelectedClient(client)
+  nextMonitor.statusBar.setSelectedClient(client)
+  withSome(this.display.getWindowName(client.window), title):
+    nextMonitor.statusBar.setActiveWindowTitle(title)
+
   this.selectedMonitor = nextMonitor
   # Unset the client being moved/resized
   this.moveResizingClient = none(Client)


### PR DESCRIPTION
Moving windows between monitors was leaving the old status on the previous monitor behind. This PR fixes that.