### PR TITLE
Fullscreen fix

### DIFF
--- a/nimdow.nimble
+++ b/nimdow.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.5.7"
+version       = "0.5.8"
 author        = "avahe-kellenberger"
 description   = "A window manager written in nim"
 license       = "GPL v2"

--- a/src/nimdow.nim
+++ b/src/nimdow.nim
@@ -15,7 +15,7 @@ when isMainModule:
     if params.len == 1:
       let param = params[0].string
       if param == "-v" or param == "--version":
-        echo "Nimdow v0.5.7"
+        echo "Nimdow v0.5.8"
         quit()
       else:
         # If given a parameter for a config file, use it instead of the default.

--- a/src/nimdowpkg/client.nim
+++ b/src/nimdowpkg/client.nim
@@ -7,10 +7,15 @@ type
   Client* = ref object of RootObj
     window*: Window
     x*: int
+    oldX*: int
     y*: int
+    oldY*: int
     width*: uint
+    oldWidth*: uint
     height*: uint
+    oldHeight*: uint
     borderWidth*: uint
+    oldBorderWidth*: uint
     isFullscreen*: bool
     isFloating*: bool
     # Non-resizable

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -454,20 +454,9 @@ proc toggleFullscreen*(this: Monitor, client: var Client) =
       cast[Pcuchar]([]),
       0
     )
+    client.borderWidth = this.config.borderWidth
     client.adjustToState(this.display)
   else:
-    # Don't invoke client.adjustToState here,
-    # since we want to be able to return the client to its normal state
-    # when/if this proc is invoked again.
-    discard XSetWindowBorderWidth(this.display, client.window, 0)
-    discard XMoveResizeWindow(
-      this.display,
-      client.window,
-      this.area.x,
-      this.area.y,
-      this.area.width.cuint,
-      this.area.height.cuint
-    )
     var arr = [$NetWMStateFullScreen]   
     discard XChangeProperty(
       this.display,
@@ -479,6 +468,12 @@ proc toggleFullscreen*(this: Monitor, client: var Client) =
       cast[Pcuchar](arr.addr),
       1
     )
+    client.x = this.area.x
+    client.y = this.area.y
+    client.width = this.area.width
+    client.height = this.area.height
+    client.borderWidth = 0
+    client.adjustToState(this.display)
     discard XRaiseWindow(this.display, client.window)
 
   client.isFullscreen = not client.isFullscreen

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -454,7 +454,11 @@ proc toggleFullscreen*(this: Monitor, client: var Client) =
       cast[Pcuchar]([]),
       0
     )
-    client.borderWidth = this.config.borderWidth
+    client.x = client.oldX
+    client.y = client.oldY
+    client.width = client.oldWidth
+    client.height = client.oldHeight
+    client.borderWidth = client.oldBorderWidth
     client.adjustToState(this.display)
   else:
     var arr = [$NetWMStateFullScreen]   
@@ -468,6 +472,12 @@ proc toggleFullscreen*(this: Monitor, client: var Client) =
       cast[Pcuchar](arr.addr),
       1
     )
+    client.oldX = client.x
+    client.oldY = client.y
+    client.oldWidth = client.width
+    client.oldHeight = client.height
+    client.oldBorderWidth = client.borderWidth
+
     client.x = this.area.x
     client.y = this.area.y
     client.width = this.area.width

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -579,6 +579,8 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
   client.height = windowAttr.height.uint
 
   discard XSetWindowBorder(this.display, window, this.windowSettings.borderColorUnfocused)
+  
+  this.configure(client)
 
   discard XSelectInput(this.display,
                        window,
@@ -590,6 +592,9 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
 
   this.selectedMonitor.addWindowToClientListProperty(window)
 
+  this.updateWindowType(client)
+  this.updateSizeHints(client)
+
   discard XMoveResizeWindow(this.display,
                             window,
                             client.x,
@@ -597,8 +602,6 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
                             client.width.cuint,
                             client.height.cuint)
 
-  this.updateWindowType(client)
-  this.updateSizeHints(client)
   this.selectedMonitor.doLayout()
   discard XMapWindow(this.display, window)
 

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -486,7 +486,6 @@ proc onConfigureRequest(this: WindowManager, e: XConfigureRequestEvent) =
           client.width.cint,
           client.height.cint
         )
-      # TODO: Is this needed?
       this.selectedMonitor.doLayout()
     else:
       this.configure(client)


### PR DESCRIPTION
Configure events are now sending the proper window geometry.

We are now caching old client geometry to properly restore clients to their original size and position after being unfullscreened.

This fixes issues with some applications such as xlunch.