### PR TITLE
Systray support

### DIFF
--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -33,7 +33,7 @@ type
     barWindow*: Window
     rootWindow: Window
     fonts: seq[PXftFont]
-    draw*: PXftDraw
+    draw: PXftDraw
     visual: PVisual
     colormap: Colormap
     fgColor*, bgColor*, selectionColor*: XftColor

--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -7,8 +7,7 @@ import
   tables,
   tag,
   client,
-  config/configloader,
-  systray
+  config/configloader
 
 converter boolToXBool(x: bool): XBool = XBool(x)
 converter XBoolToBool(x: XBool): bool = bool(x)
@@ -34,7 +33,7 @@ type
     barWindow*: Window
     rootWindow: Window
     fonts: seq[PXftFont]
-    draw: PXftDraw
+    draw*: PXftDraw
     visual: PVisual
     colormap: Colormap
     fgColor*, bgColor*, selectionColor*: XftColor

--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -7,7 +7,8 @@ import
   tables,
   tag,
   client,
-  config/configloader
+  config/configloader,
+  systray
 
 converter boolToXBool(x: bool): XBool = XBool(x)
 converter XBoolToBool(x: XBool): bool = bool(x)
@@ -153,6 +154,17 @@ proc configureBar(this: StatusBar) =
     PropModeReplace,
     cast[Pcuchar](strut.addr),
     12
+  )
+
+proc resizeForSystray*(this: StatusBar, systrayWidth: int) =
+  var width: int = this.area.width.int - systrayWidth
+  discard XMoveResizeWindow(
+    this.display,
+    this.barWindow,
+    this.area.x,
+    this.area.y,
+    width,
+    this.area.height
   )
 
 proc allocColor(this: StatusBar, color: PXRenderColor, colorPtr: PXftColor) =

--- a/src/nimdowpkg/systray.nim
+++ b/src/nimdowpkg/systray.nim
@@ -3,26 +3,37 @@ import
   client
 
 # TODO: Put this in the config file
-const iconSpacing: int = 4
+const systrayIconSpacing*: int = 4
 
-type Systray* = ref object
-  window*: Window
-  icons: seq[Client]
+type
+  Systray* = ref object
+    window*: Window
+    icons*: seq[Icon]
+  Icon* = ref object of Client
+    isMapped*: bool
+
+proc newIcon*(window: Window): Icon =
+  Icon(window: window)
 
 proc getWidth*(this: Systray): int =
   for icon in this.icons:
-    result += icon.width.int + iconSpacing
-  result = max(1, result + iconSpacing)
+    result += icon.width.int + systrayIconSpacing
+  result = max(1, result + systrayIconSpacing)
 
-proc windowToIcon*(this: Systray, window: Window): Client =
+proc windowToIcon*(this: Systray, window: Window): Icon =
   let index = this.icons.find(window)
   if index != -1:
     return this.icons[index]
 
-proc removeIcon*(this: Systray, icon: Client) =
+proc addIcon*(this: Systray, icon: Icon) =
   if icon == nil:
     return
-  let index = this.icons.find(client)
+  this.icons.insert(icon, 0)
+
+proc removeIcon*(this: Systray, icon: Icon) =
+  if icon == nil:
+    return
+  let index = this.icons.find(icon)
   if index != -1:
     this.icons.delete(index)
 

--- a/src/nimdowpkg/systray.nim
+++ b/src/nimdowpkg/systray.nim
@@ -1,0 +1,28 @@
+import
+  x11 / [x],
+  client
+
+# TODO: Put this in the config file
+const iconSpacing: int = 4
+
+type Systray* = ref object
+  window*: Window
+  icons: seq[Client]
+
+proc getWidth*(this: Systray): int =
+  for icon in this.icons:
+    result += icon.width.int + iconSpacing
+  result = max(1, result + iconSpacing)
+
+proc windowToIcon*(this: Systray, window: Window): Client =
+  let index = this.icons.find(window)
+  if index != -1:
+    return this.icons[index]
+
+proc removeIcon*(this: Systray, icon: Client) =
+  if icon == nil:
+    return
+  let index = this.icons.find(client)
+  if index != -1:
+    this.icons.delete(index)
+

--- a/src/nimdowpkg/systray.nim
+++ b/src/nimdowpkg/systray.nim
@@ -1,6 +1,7 @@
 import
   x11 / [x],
-  client
+  client,
+  logger
 
 # TODO: Put this in the config file
 const systrayIconSpacing*: int = 4
@@ -19,6 +20,9 @@ proc getWidth*(this: Systray): int =
   for icon in this.icons:
     result += icon.width.int + systrayIconSpacing
   result = max(1, result + systrayIconSpacing)
+
+  log "systrayWidth: " & $result
+  log "systray icons len: " & $this.icons.len
 
 proc windowToIcon*(this: Systray, window: Window): Icon =
   let index = this.icons.find(window)

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1057,7 +1057,6 @@ proc updateSystray(this: WindowManager) =
   discard XMapWindow(this.display, this.systray.window)
   discard XMapSubwindows(this.display, this.systray.window)
 
-  # TODO: Redraw background of systray
   discard XSync(this.display, false)
 
 proc updateSystrayIconGeom(this: WindowManager, icon: Icon, width, height: int) =
@@ -1072,8 +1071,6 @@ proc updateSystrayIconGeom(this: WindowManager, icon: Icon, width, height: int) 
     icon.width = width
   else:
     icon.width = int(barHeight.float * (width / height))
-
-  # TODO: this.applySizeHints()
 
   # Force icons into the systray dimensions if they don't want to
   if icon.height > barHeight:
@@ -1229,7 +1226,6 @@ proc onPropertyNotify(this: WindowManager, e: XPropertyEvent) =
   let icon = this.systray.windowToIcon(e.window)
   if icon != nil:
     if e.atom == XA_WM_NORMAL_HINTS:
-      # TODO: this.updateSizeHints()
       this.updateSystrayIconGeom(icon, icon.width.int, icon.height.int)
     else:
       this.updateSystrayIconState(icon, e)

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -35,11 +35,7 @@ const
 
   SYSTEM_TRAY_REQUEST_DOCK = 0
 
-  # XEMBED messages
   XEMBED_EMBEDDED_NOTIFY = 0
-  XEMBED_FOCUS_IN = 4
-  XEMBED_MODALITY_ON = 10
-
   XEMBED_MAPPED = 1 shl 0
   XEMBED_WINDOW_ACTIVATE = 1
   XEMBED_WINDOW_DEACTIVATE = 2
@@ -47,7 +43,6 @@ const
   VERSION_MAJOR = 0
   VERSION_MINOR = 0
   XEMBED_EMBEDDED_VERSION = (VERSION_MAJOR shl 16) or VERSION_MINOR
-
 
 type
   MouseState* = enum
@@ -666,6 +661,12 @@ proc onClientMessage(this: WindowManager, e: XClientMessageEvent) =
         icon.window,
         StructureNotifyMask or PropertyChangeMask or ResizeRedirectMask
       )
+
+      var classHint: XClassHint
+      classHint.res_name = "nimdowsystray"
+      classHint.res_class = "nimdowsystray"
+      discard XSetClassHint(this.display, icon.window, classHint.addr)
+
       discard XReparentWindow(
         this.display,
         icon.window,
@@ -688,16 +689,9 @@ proc onClientMessage(this: WindowManager, e: XClientMessageEvent) =
         this.systray.window.clong,
         XEMBED_EMBEDDED_VERSION
       )
-      # TODO: FIXME not sure if I have to send these events, too
-      # sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_FOCUS_IN, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
-      # this.display.sendEvent(
-
-      # )
-
-      # sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
-      # sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_MODALITY_ON, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
 
       discard XSync(this.display, false)
+
       this.systrayMonitor.statusBar.resizeForSystray(this.systray.getWidth())
       this.updateSystray()
       this.setClientState(Client(icon), NormalState)

--- a/src/nimdowpkg/xatoms.nim
+++ b/src/nimdowpkg/xatoms.nim
@@ -11,7 +11,7 @@ type
     WMName, WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast
   NetAtom* = enum
     NetActiveWindow, NetSupported,
-    # NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
+    NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
     NetWMName, NetWMState, NetWMStateAbove, NetWMStateSticky,
     NetSupportingWMCheck, NetWMStateFullScreen, NetClientList, NetWMStrutPartial,
     NetWMWindowType, NetWMWindowTypeNormal, NetWMWindowTypeDialog, NetWMWindowTypeUtility,
@@ -21,8 +21,7 @@ type
     NetWMDesktop, NetDesktopViewport, NetNumberOfDesktops, NetCurrentDesktop, NetDesktopNames,
     NetLast
   XAtom* = enum
-    Manager, XLast
-    # Xembed, XembedInfo
+    Manager, Xembed, XembedInfo, XLast
 
 var WMAtoms*: array[ord(WMLast), Atom]
 var NetAtoms*: array[ord(NetLast), Atom]
@@ -51,10 +50,10 @@ proc getNetAtoms*(display: PDisplay): array[ord(NetLast), Atom] =
   [
     XInternAtom(display, "_NET_ACTIVE_WINDOW", false),
     XInternAtom(display, "_NET_SUPPORTED", false),
-    # XInternAtom(display, "_NET_SYSTEM_TRAY_S0", false),
-    # XInternAtom(display, "_NET_SYSTEM_TRAY_OPCODE", false),
-    # XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION", false),
-    # XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_S0", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_OPCODE", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION", false),
+    XInternAtom(display, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", false),
     XInternAtom(display, "_NET_WM_NAME", false),
     XInternAtom(display, "_NET_WM_STATE", false),
     XInternAtom(display, "_NET_WM_STATE_ABOVE", false),
@@ -85,8 +84,8 @@ proc getNetAtoms*(display: PDisplay): array[ord(NetLast), Atom] =
 proc getXAtoms*(display: PDisplay): array[ord(XLast), Atom] =
   [
     XInternAtom(display, "MANAGER", false),
-    # XInternAtom(display, "_XEMBED", false),
-    # XInternAtom(display, "_XEMBED_INFO", false)
+    XInternAtom(display, "_XEMBED", false),
+    XInternAtom(display, "_XEMBED_INFO", false)
   ]
 
 proc getProperty*[T](

--- a/systray.diff
+++ b/systray.diff
@@ -1,0 +1,741 @@
+From f3e4acadd74cf392fdb7bf406c2edfcf5425eee8 Mon Sep 17 00:00:00 2001
+From: Michel Boaventura <michel.boaventura@protonmail.com>
+Date: Wed, 10 Jun 2020 12:50:03 -0300
+Subject: [PATCH] Implements a system tray for dwm
+
+---
+ config.def.h |   4 +
+ dwm.c        | 403 +++++++++++++++++++++++++++++++++++++++++++++++----
+ 2 files changed, 381 insertions(+), 26 deletions(-)
+
+diff --git a/config.def.h b/config.def.h
+index 1c0b587..2d824d1 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -3,6 +3,10 @@
+ /* appearance */
+ static const unsigned int borderpx  = 1;        /* border pixel of windows */
+ static const unsigned int snap      = 32;       /* snap pixel */
++static const unsigned int systraypinning = 0;   /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor X */
++static const unsigned int systrayspacing = 2;   /* systray spacing */
++static const int systraypinningfailfirst = 1;   /* 1: if pinning fails, display systray on the first monitor, False: display systray on the last monitor*/
++static const int showsystray        = 1;     /* 0 means no systray */
+ static const int showbar            = 1;        /* 0 means no bar */
+ static const int topbar             = 1;        /* 0 means bottom bar */
+ static const char *fonts[]          = { "monospace:size=10" };
+diff --git a/dwm.c b/dwm.c
+index 9fd0286..ed42af7 100644
+--- a/dwm.c
++++ b/dwm.c
+@@ -57,12 +57,30 @@
+ #define TAGMASK                 ((1 << LENGTH(tags)) - 1)
+ #define TEXTW(X)                (drw_fontset_getwidth(drw, (X)) + lrpad)
+ 
++#define SYSTEM_TRAY_REQUEST_DOCK    0
++
++/* XEMBED messages */
++#define XEMBED_EMBEDDED_NOTIFY      0
++#define XEMBED_WINDOW_ACTIVATE      1
++#define XEMBED_FOCUS_IN             4
++#define XEMBED_MODALITY_ON         10
++
++#define XEMBED_MAPPED              (1 << 0)
++#define XEMBED_WINDOW_ACTIVATE      1
++#define XEMBED_WINDOW_DEACTIVATE    2
++
++#define VERSION_MAJOR               0
++#define VERSION_MINOR               0
++#define XEMBED_EMBEDDED_VERSION (VERSION_MAJOR << 16) | VERSION_MINOR
++
+ /* enums */
+ enum { CurNormal, CurResize, CurMove, CurLast }; /* cursor */
+ enum { SchemeNorm, SchemeSel }; /* color schemes */
+ enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
++       NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
+        NetWMFullscreen, NetActiveWindow, NetWMWindowType,
+        NetWMWindowTypeDialog, NetClientList, NetLast }; /* EWMH atoms */
++enum { Manager, Xembed, XembedInfo, XLast }; /* Xembed atoms */
+ enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
+ enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
+        ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
+@@ -141,6 +159,12 @@ typedef struct {
+ 	int monitor;
+ } Rule;
+ 
++typedef struct Systray   Systray;
++struct Systray {
++	Window win;
++	Client *icons;
++};
++
+ /* function declarations */
+ static void applyrules(Client *c);
+ static int applysizehints(Client *c, int *x, int *y, int *w, int *h, int interact);
+@@ -172,6 +196,7 @@ static void focusstack(const Arg *arg);
+ static Atom getatomprop(Client *c, Atom prop);
+ static int getrootptr(int *x, int *y);
+ static long getstate(Window w);
++static unsigned int getsystraywidth();
+ static int gettextprop(Window w, Atom atom, char *text, unsigned int size);
+ static void grabbuttons(Client *c, int focused);
+ static void grabkeys(void);
+@@ -189,13 +214,16 @@ static void pop(Client *);
+ static void propertynotify(XEvent *e);
+ static void quit(const Arg *arg);
+ static Monitor *recttomon(int x, int y, int w, int h);
++static void removesystrayicon(Client *i);
+ static void resize(Client *c, int x, int y, int w, int h, int interact);
++static void resizebarwin(Monitor *m);
+ static void resizeclient(Client *c, int x, int y, int w, int h);
+ static void resizemouse(const Arg *arg);
++static void resizerequest(XEvent *e);
+ static void restack(Monitor *m);
+ static void run(void);
+ static void scan(void);
+-static int sendevent(Client *c, Atom proto);
++static int sendevent(Window w, Atom proto, int m, long d0, long d1, long d2, long d3, long d4);
+ static void sendmon(Client *c, Monitor *m);
+ static void setclientstate(Client *c, long state);
+ static void setfocus(Client *c);
+@@ -207,6 +235,7 @@ static void seturgent(Client *c, int urg);
+ static void showhide(Client *c);
+ static void sigchld(int unused);
+ static void spawn(const Arg *arg);
++static Monitor *systraytomon(Monitor *m);
+ static void tag(const Arg *arg);
+ static void tagmon(const Arg *arg);
+ static void tile(Monitor *);
+@@ -224,18 +253,23 @@ static int updategeom(void);
+ static void updatenumlockmask(void);
+ static void updatesizehints(Client *c);
+ static void updatestatus(void);
++static void updatesystray(void);
++static void updatesystrayicongeom(Client *i, int w, int h);
++static void updatesystrayiconstate(Client *i, XPropertyEvent *ev);
+ static void updatetitle(Client *c);
+ static void updatewindowtype(Client *c);
+ static void updatewmhints(Client *c);
+ static void view(const Arg *arg);
+ static Client *wintoclient(Window w);
+ static Monitor *wintomon(Window w);
++static Client *wintosystrayicon(Window w);
+ static int xerror(Display *dpy, XErrorEvent *ee);
+ static int xerrordummy(Display *dpy, XErrorEvent *ee);
+ static int xerrorstart(Display *dpy, XErrorEvent *ee);
+ static void zoom(const Arg *arg);
+ 
+ /* variables */
++static Systray *systray =  NULL;
+ static const char broken[] = "broken";
+ static char stext[256];
+ static int screen;
+@@ -258,9 +292,10 @@ static void (*handler[LASTEvent]) (XEvent *) = {
+ 	[MapRequest] = maprequest,
+ 	[MotionNotify] = motionnotify,
+ 	[PropertyNotify] = propertynotify,
++	[ResizeRequest] = resizerequest,
+ 	[UnmapNotify] = unmapnotify
+ };
+-static Atom wmatom[WMLast], netatom[NetLast];
++static Atom wmatom[WMLast], netatom[NetLast], xatom[XLast];
+ static int running = 1;
+ static Cur *cursor[CurLast];
+ static Clr **scheme;
+@@ -440,7 +475,7 @@ buttonpress(XEvent *e)
+ 			arg.ui = 1 << i;
+ 		} else if (ev->x < x + blw)
+ 			click = ClkLtSymbol;
+-		else if (ev->x > selmon->ww - TEXTW(stext))
++		else if (ev->x > selmon->ww - TEXTW(stext) - getsystraywidth())
+ 			click = ClkStatusText;
+ 		else
+ 			click = ClkWinTitle;
+@@ -483,6 +518,11 @@ cleanup(void)
+ 	XUngrabKey(dpy, AnyKey, AnyModifier, root);
+ 	while (mons)
+ 		cleanupmon(mons);
++	if (showsystray) {
++		XUnmapWindow(dpy, systray->win);
++		XDestroyWindow(dpy, systray->win);
++		free(systray);
++	}
+ 	for (i = 0; i < CurLast; i++)
+ 		drw_cur_free(drw, cursor[i]);
+ 	for (i = 0; i < LENGTH(colors); i++)
+@@ -513,9 +553,57 @@ cleanupmon(Monitor *mon)
+ void
+ clientmessage(XEvent *e)
+ {
++	XWindowAttributes wa;
++	XSetWindowAttributes swa;
+ 	XClientMessageEvent *cme = &e->xclient;
+ 	Client *c = wintoclient(cme->window);
+ 
++	if (showsystray && cme->window == systray->win && cme->message_type == netatom[NetSystemTrayOP]) {
++		/* add systray icons */
++		if (cme->data.l[1] == SYSTEM_TRAY_REQUEST_DOCK) {
++			if (!(c = (Client *)calloc(1, sizeof(Client))))
++				die("fatal: could not malloc() %u bytes\n", sizeof(Client));
++			if (!(c->win = cme->data.l[2])) {
++				free(c);
++				return;
++			}
++			c->mon = selmon;
++			c->next = systray->icons;
++			systray->icons = c;
++			if (!XGetWindowAttributes(dpy, c->win, &wa)) {
++				/* use sane defaults */
++				wa.width = bh;
++				wa.height = bh;
++				wa.border_width = 0;
++			}
++			c->x = c->oldx = c->y = c->oldy = 0;
++			c->w = c->oldw = wa.width;
++			c->h = c->oldh = wa.height;
++			c->oldbw = wa.border_width;
++			c->bw = 0;
++			c->isfloating = True;
++			/* reuse tags field as mapped status */
++			c->tags = 1;
++			updatesizehints(c);
++			updatesystrayicongeom(c, wa.width, wa.height);
++			XAddToSaveSet(dpy, c->win);
++			XSelectInput(dpy, c->win, StructureNotifyMask | PropertyChangeMask | ResizeRedirectMask);
++			XReparentWindow(dpy, c->win, systray->win, 0, 0);
++			/* use parents background color */
++			swa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
++			XChangeWindowAttributes(dpy, c->win, CWBackPixel, &swa);
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_EMBEDDED_NOTIFY, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			/* FIXME not sure if I have to send these events, too */
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_FOCUS_IN, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_MODALITY_ON, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			XSync(dpy, False);
++			resizebarwin(selmon);
++			updatesystray();
++			setclientstate(c, NormalState);
++		}
++		return;
++	}
+ 	if (!c)
+ 		return;
+ 	if (cme->message_type == netatom[NetWMState]) {
+@@ -568,7 +656,7 @@ configurenotify(XEvent *e)
+ 				for (c = m->clients; c; c = c->next)
+ 					if (c->isfullscreen)
+ 						resizeclient(c, m->mx, m->my, m->mw, m->mh);
+-				XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, m->ww, bh);
++				resizebarwin(m);
+ 			}
+ 			focus(NULL);
+ 			arrange(NULL);
+@@ -653,6 +741,11 @@ destroynotify(XEvent *e)
+ 
+ 	if ((c = wintoclient(ev->window)))
+ 		unmanage(c, 1);
++	else if ((c = wintosystrayicon(ev->window))) {
++		removesystrayicon(c);
++		resizebarwin(selmon);
++		updatesystray();
++	}
+ }
+ 
+ void
+@@ -696,19 +789,23 @@ dirtomon(int dir)
+ void
+ drawbar(Monitor *m)
+ {
+-	int x, w, tw = 0;
++	int x, w, tw = 0, stw = 0;
+ 	int boxs = drw->fonts->h / 9;
+ 	int boxw = drw->fonts->h / 6 + 2;
+ 	unsigned int i, occ = 0, urg = 0;
+ 	Client *c;
+ 
++	if(showsystray && m == systraytomon(m))
++		stw = getsystraywidth();
++
+ 	/* draw status first so it can be overdrawn by tags later */
+ 	if (m == selmon) { /* status is only drawn on selected monitor */
+ 		drw_setscheme(drw, scheme[SchemeNorm]);
+-		tw = TEXTW(stext) - lrpad + 2; /* 2px right padding */
+-		drw_text(drw, m->ww - tw, 0, tw, bh, 0, stext, 0);
++		tw = TEXTW(stext) - lrpad / 2 + 2; /* 2px right padding */
++		drw_text(drw, m->ww - tw - stw, 0, tw, bh, lrpad / 2 - 2, stext, 0);
+ 	}
+ 
++	resizebarwin(m);
+ 	for (c = m->clients; c; c = c->next) {
+ 		occ |= c->tags;
+ 		if (c->isurgent)
+@@ -729,7 +826,7 @@ drawbar(Monitor *m)
+ 	drw_setscheme(drw, scheme[SchemeNorm]);
+ 	x = drw_text(drw, x, 0, w, bh, lrpad / 2, m->ltsymbol, 0);
+ 
+-	if ((w = m->ww - tw - x) > bh) {
++	if ((w = m->ww - tw - stw - x) > bh) {
+ 		if (m->sel) {
+ 			drw_setscheme(drw, scheme[m == selmon ? SchemeSel : SchemeNorm]);
+ 			drw_text(drw, x, 0, w, bh, lrpad / 2, m->sel->name, 0);
+@@ -740,7 +837,7 @@ drawbar(Monitor *m)
+ 			drw_rect(drw, x, 0, w, bh, 1, 1);
+ 		}
+ 	}
+-	drw_map(drw, m->barwin, 0, 0, m->ww, bh);
++	drw_map(drw, m->barwin, 0, 0, m->ww - stw, bh);
+ }
+ 
+ void
+@@ -777,8 +874,11 @@ expose(XEvent *e)
+ 	Monitor *m;
+ 	XExposeEvent *ev = &e->xexpose;
+ 
+-	if (ev->count == 0 && (m = wintomon(ev->window)))
++	if (ev->count == 0 && (m = wintomon(ev->window))) {
+ 		drawbar(m);
++		if (m == selmon)
++			updatesystray();
++	}
+ }
+ 
+ void
+@@ -863,10 +963,17 @@ getatomprop(Client *c, Atom prop)
+ 	unsigned long dl;
+ 	unsigned char *p = NULL;
+ 	Atom da, atom = None;
++	/* FIXME getatomprop should return the number of items and a pointer to
++	 * the stored data instead of this workaround */
++	Atom req = XA_ATOM;
++	if (prop == xatom[XembedInfo])
++		req = xatom[XembedInfo];
+ 
+-	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, XA_ATOM,
++	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, req,
+ 		&da, &di, &dl, &dl, &p) == Success && p) {
+ 		atom = *(Atom *)p;
++		if (da == xatom[XembedInfo] && dl == 2)
++			atom = ((Atom *)p)[1];
+ 		XFree(p);
+ 	}
+ 	return atom;
+@@ -900,6 +1007,16 @@ getstate(Window w)
+ 	return result;
+ }
+ 
++unsigned int
++getsystraywidth()
++{
++	unsigned int w = 0;
++	Client *i;
++	if(showsystray)
++		for(i = systray->icons; i; w += i->w + systrayspacing, i = i->next) ;
++	return w ? w + systrayspacing : 1;
++}
++
+ int
+ gettextprop(Window w, Atom atom, char *text, unsigned int size)
+ {
+@@ -1004,7 +1121,7 @@ killclient(const Arg *arg)
+ {
+ 	if (!selmon->sel)
+ 		return;
+-	if (!sendevent(selmon->sel, wmatom[WMDelete])) {
++	if (!sendevent(selmon->sel->win, wmatom[WMDelete], NoEventMask, wmatom[WMDelete], CurrentTime, 0 , 0, 0)) {
+ 		XGrabServer(dpy);
+ 		XSetErrorHandler(xerrordummy);
+ 		XSetCloseDownMode(dpy, DestroyAll);
+@@ -1092,6 +1209,12 @@ maprequest(XEvent *e)
+ {
+ 	static XWindowAttributes wa;
+ 	XMapRequestEvent *ev = &e->xmaprequest;
++	Client *i;
++	if ((i = wintosystrayicon(ev->window))) {
++		sendevent(i->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0, systray->win, XEMBED_EMBEDDED_VERSION);
++		resizebarwin(selmon);
++		updatesystray();
++	}
+ 
+ 	if (!XGetWindowAttributes(dpy, ev->window, &wa))
+ 		return;
+@@ -1216,6 +1339,16 @@ propertynotify(XEvent *e)
+ 	Window trans;
+ 	XPropertyEvent *ev = &e->xproperty;
+ 
++	if ((c = wintosystrayicon(ev->window))) {
++		if (ev->atom == XA_WM_NORMAL_HINTS) {
++			updatesizehints(c);
++			updatesystrayicongeom(c, c->w, c->h);
++		}
++		else
++			updatesystrayiconstate(c, ev);
++		resizebarwin(selmon);
++		updatesystray();
++	}
+ 	if ((ev->window == root) && (ev->atom == XA_WM_NAME))
+ 		updatestatus();
+ 	else if (ev->state == PropertyDelete)
+@@ -1266,6 +1399,20 @@ recttomon(int x, int y, int w, int h)
+ 	return r;
+ }
+ 
++void
++removesystrayicon(Client *i)
++{
++	Client **ii;
++
++	if (!showsystray || !i)
++		return;
++	for (ii = &systray->icons; *ii && *ii != i; ii = &(*ii)->next);
++	if (ii)
++		*ii = i->next;
++	free(i);
++}
++
++
+ void
+ resize(Client *c, int x, int y, int w, int h, int interact)
+ {
+@@ -1273,6 +1420,14 @@ resize(Client *c, int x, int y, int w, int h, int interact)
+ 		resizeclient(c, x, y, w, h);
+ }
+ 
++void
++resizebarwin(Monitor *m) {
++	unsigned int w = m->ww;
++	if (showsystray && m == systraytomon(m))
++		w -= getsystraywidth();
++	XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, w, bh);
++}
++
+ void
+ resizeclient(Client *c, int x, int y, int w, int h)
+ {
+@@ -1345,6 +1500,19 @@ resizemouse(const Arg *arg)
+ 	}
+ }
+ 
++void
++resizerequest(XEvent *e)
++{
++	XResizeRequestEvent *ev = &e->xresizerequest;
++	Client *i;
++
++	if ((i = wintosystrayicon(ev->window))) {
++		updatesystrayicongeom(i, ev->width, ev->height);
++		resizebarwin(selmon);
++		updatesystray();
++	}
++}
++
+ void
+ restack(Monitor *m)
+ {
+@@ -1434,26 +1602,36 @@ setclientstate(Client *c, long state)
+ }
+ 
+ int
+-sendevent(Client *c, Atom proto)
++sendevent(Window w, Atom proto, int mask, long d0, long d1, long d2, long d3, long d4)
+ {
+ 	int n;
+-	Atom *protocols;
++	Atom *protocols, mt;
+ 	int exists = 0;
+ 	XEvent ev;
+ 
+-	if (XGetWMProtocols(dpy, c->win, &protocols, &n)) {
+-		while (!exists && n--)
+-			exists = protocols[n] == proto;
+-		XFree(protocols);
++	if (proto == wmatom[WMTakeFocus] || proto == wmatom[WMDelete]) {
++		mt = wmatom[WMProtocols];
++		if (XGetWMProtocols(dpy, w, &protocols, &n)) {
++			while (!exists && n--)
++				exists = protocols[n] == proto;
++			XFree(protocols);
++		}
++	}
++	else {
++		exists = True;
++		mt = proto;
+ 	}
+ 	if (exists) {
+ 		ev.type = ClientMessage;
+-		ev.xclient.window = c->win;
+-		ev.xclient.message_type = wmatom[WMProtocols];
++		ev.xclient.window = w;
++		ev.xclient.message_type = mt;
+ 		ev.xclient.format = 32;
+-		ev.xclient.data.l[0] = proto;
+-		ev.xclient.data.l[1] = CurrentTime;
+-		XSendEvent(dpy, c->win, False, NoEventMask, &ev);
++		ev.xclient.data.l[0] = d0;
++		ev.xclient.data.l[1] = d1;
++		ev.xclient.data.l[2] = d2;
++		ev.xclient.data.l[3] = d3;
++		ev.xclient.data.l[4] = d4;
++		XSendEvent(dpy, w, False, mask, &ev);
+ 	}
+ 	return exists;
+ }
+@@ -1467,7 +1645,7 @@ setfocus(Client *c)
+ 			XA_WINDOW, 32, PropModeReplace,
+ 			(unsigned char *) &(c->win), 1);
+ 	}
+-	sendevent(c, wmatom[WMTakeFocus]);
++	sendevent(c->win, wmatom[WMTakeFocus], NoEventMask, wmatom[WMTakeFocus], CurrentTime, 0, 0, 0);
+ }
+ 
+ void
+@@ -1556,6 +1734,10 @@ setup(void)
+ 	wmatom[WMTakeFocus] = XInternAtom(dpy, "WM_TAKE_FOCUS", False);
+ 	netatom[NetActiveWindow] = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
+ 	netatom[NetSupported] = XInternAtom(dpy, "_NET_SUPPORTED", False);
++	netatom[NetSystemTray] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_S0", False);
++	netatom[NetSystemTrayOP] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_OPCODE", False);
++	netatom[NetSystemTrayOrientation] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION", False);
++	netatom[NetSystemTrayOrientationHorz] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", False);
+ 	netatom[NetWMName] = XInternAtom(dpy, "_NET_WM_NAME", False);
+ 	netatom[NetWMState] = XInternAtom(dpy, "_NET_WM_STATE", False);
+ 	netatom[NetWMCheck] = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+@@ -1563,6 +1745,9 @@ setup(void)
+ 	netatom[NetWMWindowType] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
+ 	netatom[NetWMWindowTypeDialog] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
+ 	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
++	xatom[Manager] = XInternAtom(dpy, "MANAGER", False);
++	xatom[Xembed] = XInternAtom(dpy, "_XEMBED", False);
++	xatom[XembedInfo] = XInternAtom(dpy, "_XEMBED_INFO", False);
+ 	/* init cursors */
+ 	cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
+ 	cursor[CurResize] = drw_cur_create(drw, XC_sizing);
+@@ -1571,6 +1756,8 @@ setup(void)
+ 	scheme = ecalloc(LENGTH(colors), sizeof(Clr *));
+ 	for (i = 0; i < LENGTH(colors); i++)
+ 		scheme[i] = drw_scm_create(drw, colors[i], 3);
++	/* init system tray */
++	updatesystray();
+ 	/* init bars */
+ 	updatebars();
+ 	updatestatus();
+@@ -1704,7 +1891,18 @@ togglebar(const Arg *arg)
+ {
+ 	selmon->showbar = !selmon->showbar;
+ 	updatebarpos(selmon);
+-	XMoveResizeWindow(dpy, selmon->barwin, selmon->wx, selmon->by, selmon->ww, bh);
++	resizebarwin(selmon);
++	if (showsystray) {
++		XWindowChanges wc;
++		if (!selmon->showbar)
++			wc.y = -bh;
++		else if (selmon->showbar) {
++			wc.y = 0;
++			if (!selmon->topbar)
++				wc.y = selmon->mh - bh;
++		}
++		XConfigureWindow(dpy, systray->win, CWY, &wc);
++	}
+ 	arrange(selmon);
+ }
+ 
+@@ -1799,11 +1997,18 @@ unmapnotify(XEvent *e)
+ 		else
+ 			unmanage(c, 0);
+ 	}
++	else if ((c = wintosystrayicon(ev->window))) {
++		/* KLUDGE! sometimes icons occasionally unmap their windows, but do
++		 * _not_ destroy them. We map those windows back */
++		XMapRaised(dpy, c->win);
++		updatesystray();
++	}
+ }
+ 
+ void
+ updatebars(void)
+ {
++	unsigned int w;
+ 	Monitor *m;
+ 	XSetWindowAttributes wa = {
+ 		.override_redirect = True,
+@@ -1814,10 +2019,15 @@ updatebars(void)
+ 	for (m = mons; m; m = m->next) {
+ 		if (m->barwin)
+ 			continue;
+-		m->barwin = XCreateWindow(dpy, root, m->wx, m->by, m->ww, bh, 0, DefaultDepth(dpy, screen),
++		w = m->ww;
++		if (showsystray && m == systraytomon(m))
++			w -= getsystraywidth();
++		m->barwin = XCreateWindow(dpy, root, m->wx, m->by, w, bh, 0, DefaultDepth(dpy, screen),
+ 				CopyFromParent, DefaultVisual(dpy, screen),
+ 				CWOverrideRedirect|CWBackPixmap|CWEventMask, &wa);
+ 		XDefineCursor(dpy, m->barwin, cursor[CurNormal]->cursor);
++		if (showsystray && m == systraytomon(m))
++			XMapRaised(dpy, systray->win);
+ 		XMapRaised(dpy, m->barwin);
+ 		XSetClassHint(dpy, m->barwin, &ch);
+ 	}
+@@ -1993,6 +2203,121 @@ updatestatus(void)
+ 	if (!gettextprop(root, XA_WM_NAME, stext, sizeof(stext)))
+ 		strcpy(stext, "dwm-"VERSION);
+ 	drawbar(selmon);
++	updatesystray();
++}
++
++void
++updatesystrayicongeom(Client *i, int w, int h)
++{
++	if (i) {
++		i->h = bh;
++		if (w == h)
++			i->w = bh;
++		else if (h == bh)
++			i->w = w;
++		else
++			i->w = (int) ((float)bh * ((float)w / (float)h));
++		applysizehints(i, &(i->x), &(i->y), &(i->w), &(i->h), False);
++		/* force icons into the systray dimensions if they don't want to */
++		if (i->h > bh) {
++			if (i->w == i->h)
++				i->w = bh;
++			else
++				i->w = (int) ((float)bh * ((float)i->w / (float)i->h));
++			i->h = bh;
++		}
++	}
++}
++
++void
++updatesystrayiconstate(Client *i, XPropertyEvent *ev)
++{
++	long flags;
++	int code = 0;
++
++	if (!showsystray || !i || ev->atom != xatom[XembedInfo] ||
++			!(flags = getatomprop(i, xatom[XembedInfo])))
++		return;
++
++	if (flags & XEMBED_MAPPED && !i->tags) {
++		i->tags = 1;
++		code = XEMBED_WINDOW_ACTIVATE;
++		XMapRaised(dpy, i->win);
++		setclientstate(i, NormalState);
++	}
++	else if (!(flags & XEMBED_MAPPED) && i->tags) {
++		i->tags = 0;
++		code = XEMBED_WINDOW_DEACTIVATE;
++		XUnmapWindow(dpy, i->win);
++		setclientstate(i, WithdrawnState);
++	}
++	else
++		return;
++	sendevent(i->win, xatom[Xembed], StructureNotifyMask, CurrentTime, code, 0,
++			systray->win, XEMBED_EMBEDDED_VERSION);
++}
++
++void
++updatesystray(void)
++{
++	XSetWindowAttributes wa;
++	XWindowChanges wc;
++	Client *i;
++	Monitor *m = systraytomon(NULL);
++	unsigned int x = m->mx + m->mw;
++	unsigned int w = 1;
++
++	if (!showsystray)
++		return;
++	if (!systray) {
++		/* init systray */
++		if (!(systray = (Systray *)calloc(1, sizeof(Systray))))
++			die("fatal: could not malloc() %u bytes\n", sizeof(Systray));
++		systray->win = XCreateSimpleWindow(dpy, root, x, m->by, w, bh, 0, 0, scheme[SchemeSel][ColBg].pixel);
++		wa.event_mask        = ButtonPressMask | ExposureMask;
++		wa.override_redirect = True;
++		wa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
++		XSelectInput(dpy, systray->win, SubstructureNotifyMask);
++		XChangeProperty(dpy, systray->win, netatom[NetSystemTrayOrientation], XA_CARDINAL, 32,
++				PropModeReplace, (unsigned char *)&netatom[NetSystemTrayOrientationHorz], 1);
++		XChangeWindowAttributes(dpy, systray->win, CWEventMask|CWOverrideRedirect|CWBackPixel, &wa);
++		XMapRaised(dpy, systray->win);
++		XSetSelectionOwner(dpy, netatom[NetSystemTray], systray->win, CurrentTime);
++		if (XGetSelectionOwner(dpy, netatom[NetSystemTray]) == systray->win) {
++			sendevent(root, xatom[Manager], StructureNotifyMask, CurrentTime, netatom[NetSystemTray], systray->win, 0, 0);
++			XSync(dpy, False);
++		}
++		else {
++			fprintf(stderr, "dwm: unable to obtain system tray.\n");
++			free(systray);
++			systray = NULL;
++			return;
++		}
++	}
++	for (w = 0, i = systray->icons; i; i = i->next) {
++		/* make sure the background color stays the same */
++		wa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
++		XChangeWindowAttributes(dpy, i->win, CWBackPixel, &wa);
++		XMapRaised(dpy, i->win);
++		w += systrayspacing;
++		i->x = w;
++		XMoveResizeWindow(dpy, i->win, i->x, 0, i->w, i->h);
++		w += i->w;
++		if (i->mon != m)
++			i->mon = m;
++	}
++	w = w ? w + systrayspacing : 1;
++	x -= w;
++	XMoveResizeWindow(dpy, systray->win, x, m->by, w, bh);
++	wc.x = x; wc.y = m->by; wc.width = w; wc.height = bh;
++	wc.stack_mode = Above; wc.sibling = m->barwin;
++	XConfigureWindow(dpy, systray->win, CWX|CWY|CWWidth|CWHeight|CWSibling|CWStackMode, &wc);
++	XMapWindow(dpy, systray->win);
++	XMapSubwindows(dpy, systray->win);
++	/* redraw background */
++	XSetForeground(dpy, drw->gc, scheme[SchemeNorm][ColBg].pixel);
++	XFillRectangle(dpy, systray->win, drw->gc, 0, 0, w, bh);
++	XSync(dpy, False);
+ }
+ 
+ void
+@@ -2060,6 +2385,16 @@ wintoclient(Window w)
+ 	return NULL;
+ }
+ 
++Client *
++wintosystrayicon(Window w) {
++	Client *i = NULL;
++
++	if (!showsystray || !w)
++		return i;
++	for (i = systray->icons; i && i->win != w; i = i->next) ;
++	return i;
++}
++
+ Monitor *
+ wintomon(Window w)
+ {
+@@ -2113,6 +2448,22 @@ xerrorstart(Display *dpy, XErrorEvent *ee)
+ 	return -1;
+ }
+ 
++Monitor *
++systraytomon(Monitor *m) {
++	Monitor *t;
++	int i, n;
++	if(!systraypinning) {
++		if(!m)
++			return selmon;
++		return m == selmon ? m : NULL;
++	}
++	for(n = 1, t = mons; t && t->next; n++, t = t->next) ;
++	for(i = 1, t = mons; t && t->next && i < systraypinning; i++, t = t->next) ;
++	if(systraypinningfailfirst && n < systraypinning)
++		return mons;
++	return t;
++}
++
+ void
+ zoom(const Arg *arg)
+ {
+-- 
+2.27.0
+
+

--- a/systray.diff
+++ b/systray.diff
@@ -30,7 +30,7 @@ index 9fd0286..ed42af7 100644
 @@ -57,12 +57,30 @@
  #define TAGMASK                 ((1 << LENGTH(tags)) - 1)
  #define TEXTW(X)                (drw_fontset_getwidth(drw, (X)) + lrpad)
- 
+
 +#define SYSTEM_TRAY_REQUEST_DOCK    0
 +
 +/* XEMBED messages */
@@ -55,13 +55,14 @@ index 9fd0286..ed42af7 100644
         NetWMFullscreen, NetActiveWindow, NetWMWindowType,
         NetWMWindowTypeDialog, NetClientList, NetLast }; /* EWMH atoms */
 +enum { Manager, Xembed, XembedInfo, XLast }; /* Xembed atoms */
+
  enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
  enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
         ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
 @@ -141,6 +159,12 @@ typedef struct {
  	int monitor;
  } Rule;
- 
+
 +typedef struct Systray   Systray;
 +struct Systray {
 +	Window win;
@@ -123,7 +124,7 @@ index 9fd0286..ed42af7 100644
  static int xerrordummy(Display *dpy, XErrorEvent *ee);
  static int xerrorstart(Display *dpy, XErrorEvent *ee);
  static void zoom(const Arg *arg);
- 
+
  /* variables */
 +static Systray *systray =  NULL;
  static const char broken[] = "broken";
@@ -170,7 +171,7 @@ index 9fd0286..ed42af7 100644
 +	XSetWindowAttributes swa;
  	XClientMessageEvent *cme = &e->xclient;
  	Client *c = wintoclient(cme->window);
- 
+
 +	if (showsystray && cme->window == systray->win && cme->message_type == netatom[NetSystemTrayOP]) {
 +		/* add systray icons */
 +		if (cme->data.l[1] == SYSTEM_TRAY_REQUEST_DOCK) {
@@ -230,7 +231,7 @@ index 9fd0286..ed42af7 100644
  			focus(NULL);
  			arrange(NULL);
 @@ -653,6 +741,11 @@ destroynotify(XEvent *e)
- 
+
  	if ((c = wintoclient(ev->window)))
  		unmanage(c, 1);
 +	else if ((c = wintosystrayicon(ev->window))) {
@@ -239,7 +240,7 @@ index 9fd0286..ed42af7 100644
 +		updatesystray();
 +	}
  }
- 
+
  void
 @@ -696,19 +789,23 @@ dirtomon(int dir)
  void
@@ -251,7 +252,7 @@ index 9fd0286..ed42af7 100644
  	int boxw = drw->fonts->h / 6 + 2;
  	unsigned int i, occ = 0, urg = 0;
  	Client *c;
- 
+
 +	if(showsystray && m == systraytomon(m))
 +		stw = getsystraywidth();
 +
@@ -263,7 +264,7 @@ index 9fd0286..ed42af7 100644
 +		tw = TEXTW(stext) - lrpad / 2 + 2; /* 2px right padding */
 +		drw_text(drw, m->ww - tw - stw, 0, tw, bh, lrpad / 2 - 2, stext, 0);
  	}
- 
+
 +	resizebarwin(m);
  	for (c = m->clients; c; c = c->next) {
  		occ |= c->tags;
@@ -271,7 +272,7 @@ index 9fd0286..ed42af7 100644
 @@ -729,7 +826,7 @@ drawbar(Monitor *m)
  	drw_setscheme(drw, scheme[SchemeNorm]);
  	x = drw_text(drw, x, 0, w, bh, lrpad / 2, m->ltsymbol, 0);
- 
+
 -	if ((w = m->ww - tw - x) > bh) {
 +	if ((w = m->ww - tw - stw - x) > bh) {
  		if (m->sel) {
@@ -284,12 +285,12 @@ index 9fd0286..ed42af7 100644
 -	drw_map(drw, m->barwin, 0, 0, m->ww, bh);
 +	drw_map(drw, m->barwin, 0, 0, m->ww - stw, bh);
  }
- 
+
  void
 @@ -777,8 +874,11 @@ expose(XEvent *e)
  	Monitor *m;
  	XExposeEvent *ev = &e->xexpose;
- 
+
 -	if (ev->count == 0 && (m = wintomon(ev->window)))
 +	if (ev->count == 0 && (m = wintomon(ev->window))) {
  		drawbar(m);
@@ -297,7 +298,7 @@ index 9fd0286..ed42af7 100644
 +			updatesystray();
 +	}
  }
- 
+
  void
 @@ -863,10 +963,17 @@ getatomprop(Client *c, Atom prop)
  	unsigned long dl;
@@ -308,7 +309,7 @@ index 9fd0286..ed42af7 100644
 +	Atom req = XA_ATOM;
 +	if (prop == xatom[XembedInfo])
 +		req = xatom[XembedInfo];
- 
+
 -	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, XA_ATOM,
 +	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, req,
  		&da, &di, &dl, &dl, &p) == Success && p) {
@@ -321,7 +322,7 @@ index 9fd0286..ed42af7 100644
 @@ -900,6 +1007,16 @@ getstate(Window w)
  	return result;
  }
- 
+
 +unsigned int
 +getsystraywidth()
 +{
@@ -354,13 +355,13 @@ index 9fd0286..ed42af7 100644
 +		resizebarwin(selmon);
 +		updatesystray();
 +	}
- 
+
  	if (!XGetWindowAttributes(dpy, ev->window, &wa))
  		return;
 @@ -1216,6 +1339,16 @@ propertynotify(XEvent *e)
  	Window trans;
  	XPropertyEvent *ev = &e->xproperty;
- 
+
 +	if ((c = wintosystrayicon(ev->window))) {
 +		if (ev->atom == XA_WM_NORMAL_HINTS) {
 +			updatesizehints(c);
@@ -377,7 +378,7 @@ index 9fd0286..ed42af7 100644
 @@ -1266,6 +1399,20 @@ recttomon(int x, int y, int w, int h)
  	return r;
  }
- 
+
 +void
 +removesystrayicon(Client *i)
 +{
@@ -398,7 +399,7 @@ index 9fd0286..ed42af7 100644
 @@ -1273,6 +1420,14 @@ resize(Client *c, int x, int y, int w, int h, int interact)
  		resizeclient(c, x, y, w, h);
  }
- 
+
 +void
 +resizebarwin(Monitor *m) {
 +	unsigned int w = m->ww;
@@ -413,7 +414,7 @@ index 9fd0286..ed42af7 100644
 @@ -1345,6 +1500,19 @@ resizemouse(const Arg *arg)
  	}
  }
- 
+
 +void
 +resizerequest(XEvent *e)
 +{
@@ -432,7 +433,7 @@ index 9fd0286..ed42af7 100644
  {
 @@ -1434,26 +1602,36 @@ setclientstate(Client *c, long state)
  }
- 
+
  int
 -sendevent(Client *c, Atom proto)
 +sendevent(Window w, Atom proto, int mask, long d0, long d1, long d2, long d3, long d4)
@@ -442,7 +443,7 @@ index 9fd0286..ed42af7 100644
 +	Atom *protocols, mt;
  	int exists = 0;
  	XEvent ev;
- 
+
 -	if (XGetWMProtocols(dpy, c->win, &protocols, &n)) {
 -		while (!exists && n--)
 -			exists = protocols[n] == proto;
@@ -485,7 +486,7 @@ index 9fd0286..ed42af7 100644
 -	sendevent(c, wmatom[WMTakeFocus]);
 +	sendevent(c->win, wmatom[WMTakeFocus], NoEventMask, wmatom[WMTakeFocus], CurrentTime, 0, 0, 0);
  }
- 
+
  void
 @@ -1556,6 +1734,10 @@ setup(void)
  	wmatom[WMTakeFocus] = XInternAtom(dpy, "WM_TAKE_FOCUS", False);
@@ -536,7 +537,7 @@ index 9fd0286..ed42af7 100644
 +	}
  	arrange(selmon);
  }
- 
+
 @@ -1799,11 +1997,18 @@ unmapnotify(XEvent *e)
  		else
  			unmanage(c, 0);
@@ -548,7 +549,7 @@ index 9fd0286..ed42af7 100644
 +		updatesystray();
 +	}
  }
- 
+
  void
  updatebars(void)
  {
@@ -693,12 +694,12 @@ index 9fd0286..ed42af7 100644
 +	XFillRectangle(dpy, systray->win, drw->gc, 0, 0, w, bh);
 +	XSync(dpy, False);
  }
- 
+
  void
 @@ -2060,6 +2385,16 @@ wintoclient(Window w)
  	return NULL;
  }
- 
+
 +Client *
 +wintosystrayicon(Window w) {
 +	Client *i = NULL;
@@ -715,7 +716,7 @@ index 9fd0286..ed42af7 100644
 @@ -2113,6 +2448,22 @@ xerrorstart(Display *dpy, XErrorEvent *ee)
  	return -1;
  }
- 
+
 +Monitor *
 +systraytomon(Monitor *m) {
 +	Monitor *t;
@@ -735,7 +736,7 @@ index 9fd0286..ed42af7 100644
  void
  zoom(const Arg *arg)
  {
--- 
+--
 2.27.0
 
 


### PR DESCRIPTION
Added systray support.

At the moment, the settings are hard-coded.
We can add settings to the config file at a later date.

- The first detected monitor (via xrandr) will have the systray
- The spacing between systray icons is 4 pixels