### PR TITLE
use certain prefix to decide the monitor index for status to set

### DIFF
--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1194,24 +1194,43 @@ proc renderWindowTitle(this: WindowManager, monitor: Monitor) =
     let title = this.display.getWindowName(client.window)
     this.selectedMonitor.statusBar.setActiveWindowTitle(title)
 
+proc setStatus(this: WindowManager, monitorIndex: int, status: string) =
+  if monitorIndex < 0 or monitorIndex > this.monitors.len - 1:
+    var err: ref ValueError
+    new(err)
+    err.msg = "monitor index is out of the range"
+    raise err
+  this.monitors[monitorIndex].statusBar.setStatus(status)
+
+proc setStatusForAllMonitors(this: WindowManager, status: string) =
+  for monitor in this.monitors:
+    monitor.statusBar.setStatus(status)
+
 proc renderStatus(this: WindowManager) =
   ## Renders the status on all status bars.
   var name: cstring
   if XFetchName(this.display, this.rootWindow, name.addr) == 1:
     let statuses = ($name).split("NIMDOW_MONITOR_INDEX=")
     if statuses.len == 1:
-      for monitor in this.monitors:
-        monitor.statusBar.setStatus(statuses[0])
+      this.setStatusForAllMonitors(statuses[0])
     else:
       for status in statuses[1 .. statuses.len - 1]:
         var monitorIndexAsStr = status[0..skipWhile(status, Digits)-1]
-        let monitorIndex = parseInt(monitorIndexAsStr)
+        var monitorIndex: int
+        try:
+          monitorIndex = parseInt(monitorIndexAsStr)
+        except ValueError:
+          let err = "NIMDOW_MONITOR_INDEX value is not valid"
+          log(err, lvlError)
+          this.setStatusForAllMonitors(err)
+          return
         if monitorIndex < 0 or monitorIndex > this.monitors.len - 1:
-          log("NIMDOW_MONITOR_INDEX value is out of the range", lvlError)
+          let err = "NIMDOW_MONITOR_INDEX value is out of the range"
+          log(err, lvlError)
+          this.setStatusForAllMonitors(err)
           return
         var st = status
-        st.removePrefix(monitorIndexAsStr)
-        this.monitors[monitorIndex].statusBar.setStatus(st)
+        this.setStatus(monitorIndex, st)
 
 proc windowToMonitor(this: WindowManager, window: Window): Monitor =
   for monitor in this.monitors:

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1198,19 +1198,20 @@ proc renderStatus(this: WindowManager) =
   ## Renders the status on all status bars.
   var name: cstring
   if XFetchName(this.display, this.rootWindow, name.addr) == 1:
-    var status = $name
-    if status.startsWith("NIMDOW_MONITOR_INDEX="):
-      status.removePrefix("NIMDOW_MONITOR_INDEX=")
-      var monitorIndexAsStr = status[0..skipWhile(status, Digits)-1]
-      let monitorIndex = parseInt(monitorIndexAsStr)
-      if monitorIndex < 0 or monitorIndex > this.monitors.len - 1:
-        log("NIMDOW_MONITOR_INDEX value is out of the range", lvlError)
-        return
-      status.removePrefix(monitorIndexAsStr)
-      this.monitors[monitorIndex].statusBar.setStatus(status)
-    else:
+    let statuses = ($name).split("NIMDOW_MONITOR_INDEX=")
+    if statuses.len == 1:
       for monitor in this.monitors:
-        monitor.statusBar.setStatus(status)
+        monitor.statusBar.setStatus(statuses[0])
+    else:
+      for status in statuses[1 .. statuses.len - 1]:
+        var monitorIndexAsStr = status[0..skipWhile(status, Digits)-1]
+        let monitorIndex = parseInt(monitorIndexAsStr)
+        if monitorIndex < 0 or monitorIndex > this.monitors.len - 1:
+          log("NIMDOW_MONITOR_INDEX value is out of the range", lvlError)
+          return
+        var st = status
+        st.removePrefix(monitorIndexAsStr)
+        this.monitors[monitorIndex].statusBar.setStatus(st)
 
 proc windowToMonitor(this: WindowManager, window: Window): Monitor =
   for monitor in this.monitors:

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1230,6 +1230,7 @@ proc renderStatus(this: WindowManager) =
           this.setStatusForAllMonitors(err)
           return
         var st = status
+        st.removePrefix(monitorIndexAsStr)
         this.setStatus(monitorIndex, st)
 
 proc windowToMonitor(this: WindowManager, window: Window): Monitor =

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -9,6 +9,8 @@ import
   monitor,
   statusbar,
   systray,
+  strutils,
+  parseutils,
   tag,
   area,
   config/configloader,
@@ -1196,9 +1198,19 @@ proc renderStatus(this: WindowManager) =
   ## Renders the status on all status bars.
   var name: cstring
   if XFetchName(this.display, this.rootWindow, name.addr) == 1:
-    let status = $name
-    for monitor in this.monitors:
-      monitor.statusBar.setStatus(status)
+    var status = $name
+    if status.startsWith("NIMDOW_MONITOR_INDEX="):
+      status.removePrefix("NIMDOW_MONITOR_INDEX=")
+      var monitorIndexAsStr = status[0..skipWhile(status, Digits)-1]
+      let monitorIndex = parseInt(monitorIndexAsStr)
+      if monitorIndex < 0 or monitorIndex > this.monitors.len - 1:
+        log("NIMDOW_MONITOR_INDEX value is out of the range", lvlError)
+        return
+      status.removePrefix(monitorIndexAsStr)
+      this.monitors[monitorIndex].statusBar.setStatus(status)
+    else:
+      for monitor in this.monitors:
+        monitor.statusBar.setStatus(status)
 
 proc windowToMonitor(this: WindowManager, window: Window): Monitor =
   for monitor in this.monitors:


### PR DESCRIPTION
Depending on the root window title, Nimdow now will decide for which monitor to set the status for.
It simply determines it by `NIMDOW_MONITOR_INDEX=n` prefix for the root window title. If `n` is out of the range, the error is printed, otherwise it's set for monitor by index `n`. If no prefix is provided, Nimdow sets the root window title as the status bar text for all the available monitors.

![screenshot_15 09 2020_18 46 38](https://user-images.githubusercontent.com/32128756/93226023-ed2ac100-f783-11ea-89f7-ab04bc0afd17.png)
