### PR TITLE
Add support for ANSI CSI SGR fore- and background

### DIFF
--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -3,7 +3,8 @@ import
   lists,
   tables,
   sets,
-  unicode
+  unicode,
+  strutils
 
 import
   taggedclients,
@@ -217,9 +218,10 @@ template configureColor(this: StatusBar, hexColor: int, xftColor: XftColor) =
   var
     color: XRenderColor
     rgb = toRGB(hexColor)
-  color.red = rgb.r.cushort * 256
-  color.green = rgb.g.cushort * 256
-  color.blue = rgb.b.cushort * 256
+  color.red = rgb.r.cushort shl 8
+  color.green = rgb.g.cushort shl 8
+  color.blue = rgb.b.cushort shl 8
+  color.alpha = 255 shl 8
   this.allocColor(color.addr, xftColor.unsafeAddr)
 
 proc configureColors(this: StatusBar) =
@@ -256,36 +258,198 @@ proc setConfig*(this: var StatusBar, config: BarSettings, redraw: bool = true) =
 ### Rendering procs ##
 ######################
 
-proc renderStringRightAligned(this: StatusBar, str: string, x: int, color: XftColor): int =
-  ## Renders a string at position x from the right side of the bar (barWidth - x).
-  ## Returns the length of the rendered string in pixels.
-  var
-    glyph: XGlyphInfo
-    pos = str.len
-    xLoc = x
-    stringWidth: int
+# Colors for ANSI CSI SGR coloration
+const
+  basicColors = [0x000000, 0xcd0000, 0x00cd00, 0xcdcd00,
+                 0x0000ee, 0xcd00cd, 0x00cdcd, 0xe5e5e5]
+  brightColors = [0x7f7f7f, 0xff0000, 0x00ff00, 0xffff00,
+                  0x5c5cff, 0xff00ff, 0x00ffff, 0xffffff]
+  extraColors = [0x000000, 0x800000, 0x008000, 0x808000,
+                 0x000080, 0x800080, 0x008080, 0xc0c0c0,
+                 0x808080, 0xff0000, 0x00ff00, 0xffff00,
+                 0x0000ff, 0xff00ff, 0x00ffff, 0xffffff,
+                 0x000000, 0x00005f, 0x000087, 0x0000af,
+                 0x0000d7, 0x0000ff, 0x005f00, 0x005f5f,
+                 0x005f87, 0x005faf, 0x005fd7, 0x005fff,
+                 0x008700, 0x00875f, 0x008787, 0x0087af,
+                 0x0087d7, 0x0087ff, 0x00af00, 0x00af5f,
+                 0x00af87, 0x00afaf, 0x00afd7, 0x00afff,
+                 0x00d700, 0x00d75f, 0x00d787, 0x00d7af,
+                 0x00d7d7, 0x00d7ff, 0x00ff00, 0x00ff5f,
+                 0x00ff87, 0x00ffaf, 0x00ffd7, 0x00ffff,
+                 0x5f0000, 0x5f005f, 0x5f0087, 0x5f00af,
+                 0x5f00d7, 0x5f00ff, 0x5f5f00, 0x5f5f5f,
+                 0x5f5f87, 0x5f5faf, 0x5f5fd7, 0x5f5fff,
+                 0x5f8700, 0x5f875f, 0x5f8787, 0x5f87af,
+                 0x5f87d7, 0x5f87ff, 0x5faf00, 0x5faf5f,
+                 0x5faf87, 0x5fafaf, 0x5fafd7, 0x5fafff,
+                 0x5fd700, 0x5fd75f, 0x5fd787, 0x5fd7af,
+                 0x5fd7d7, 0x5fd7ff, 0x5fff00, 0x5fff5f,
+                 0x5fff87, 0x5fffaf, 0x5fffd7, 0x5fffff,
+                 0x870000, 0x87005f, 0x870087, 0x8700af,
+                 0x8700d7, 0x8700ff, 0x875f00, 0x875f5f,
+                 0x875f87, 0x875faf, 0x875fd7, 0x875fff,
+                 0x878700, 0x87875f, 0x878787, 0x8787af,
+                 0x8787d7, 0x8787ff, 0x87af00, 0x87af5f,
+                 0x87af87, 0x87afaf, 0x87afd7, 0x87afff,
+                 0x87d700, 0x87d75f, 0x87d787, 0x87d7af,
+                 0x87d7d7, 0x87d7ff, 0x87ff00, 0x87ff5f,
+                 0x87ff87, 0x87ffaf, 0x87ffd7, 0x87ffff,
+                 0xaf0000, 0xaf005f, 0xaf0087, 0xaf00af,
+                 0xaf00d7, 0xaf00ff, 0xaf5f00, 0xaf5f5f,
+                 0xaf5f87, 0xaf5faf, 0xaf5fd7, 0xaf5fff,
+                 0xaf8700, 0xaf875f, 0xaf8787, 0xaf87af,
+                 0xaf87d7, 0xaf87ff, 0xafaf00, 0xafaf5f,
+                 0xafaf87, 0xafafaf, 0xafafd7, 0xafafff,
+                 0xafd700, 0xafd75f, 0xafd787, 0xafd7af,
+                 0xafd7d7, 0xafd7ff, 0xafff00, 0xafff5f,
+                 0xafff87, 0xafffaf, 0xafffd7, 0xafffff,
+                 0xd70000, 0xd7005f, 0xd70087, 0xd700af,
+                 0xd700d7, 0xd700ff, 0xd75f00, 0xd75f5f,
+                 0xd75f87, 0xd75faf, 0xd75fd7, 0xd75fff,
+                 0xd78700, 0xd7875f, 0xd78787, 0xd787af,
+                 0xd787d7, 0xd787ff, 0xd7af00, 0xd7af5f,
+                 0xd7af87, 0xd7afaf, 0xd7afd7, 0xd7afff,
+                 0xd7d700, 0xd7d75f, 0xd7d787, 0xd7d7af,
+                 0xd7d7d7, 0xd7d7ff, 0xd7ff00, 0xd7ff5f,
+                 0xd7ff87, 0xd7ffaf, 0xd7ffd7, 0xd7ffff,
+                 0xff0000, 0xff005f, 0xff0087, 0xff00af,
+                 0xff00d7, 0xff00ff, 0xff5f00, 0xff5f5f,
+                 0xff5f87, 0xff5faf, 0xff5fd7, 0xff5fff,
+                 0xff8700, 0xff875f, 0xff8787, 0xff87af,
+                 0xff87d7, 0xff87ff, 0xffaf00, 0xffaf5f,
+                 0xffaf87, 0xffafaf, 0xffafd7, 0xffafff,
+                 0xffd700, 0xffd75f, 0xffd787, 0xffd7af,
+                 0xffd7d7, 0xffd7ff, 0xffff00, 0xffff5f,
+                 0xffff87, 0xffffaf, 0xffffd7, 0xffffff,
+                 0x080808, 0x121212, 0x1c1c1c, 0x262626,
+                 0x303030, 0x3a3a3a, 0x444444, 0x4e4e4e,
+                 0x585858, 0x626262, 0x6c6c6c, 0x767676,
+                 0x808080, 0x8a8a8a, 0x949494, 0x9e9e9e,
+                 0xa8a8a8, 0xb2b2b2, 0xbcbcbc, 0xc6c6c6,
+                 0xd0d0d0, 0xdadada, 0xe4e4e4, 0xeeeeee]
 
-  let runes = str.toRunes()
-  for i in countdown(runes.high, runes.low):
-    let rune = runes[i]
-    pos -= rune.size
+proc renderStringRightAligned(this: StatusBar, str: string, x: int, defaultColor: XftColor): int =
+  ## Renders a string centered at position x. This supports ANSI CSI SGR colors
+  ## by using the normal 3/4
+  var
+    runeInfo: seq[(Rune, PXftFont, XGlyphInfo)]
+    stringWidth, xLoc, pos: int
+    color = defaultColor
+    bgColor = this.bgColor
+    parsingCsi = false
+    parsingSgr = false
+    invalidSgr = false
+    sgr: seq[int]
+    currentSgr: seq[Rune]
+
+  template addSgr(): untyped =
+    if currentSgr.len == 0:
+      sgr.add 0
+    else:
+      try:
+        sgr.add parseInt($currentSgr)
+      except:
+        invalidSgr = true
+    reset currentSgr
+
+  for rune in str.runes:
     let runeAddr = cast[PFcChar8](str[pos].unsafeAddr)
+    pos += rune.size
+    var foundFont = false
     for font in this.fonts:
-      if XftCharExists(this.display, font, rune.FcChar32) == 1:
+      if rune.int32 == 27:
+        parsingCsi = true
+      if not parsingCsi and  XftCharExists(this.display, font, rune.FcChar32) == 1:
+        var glyph: XGlyphInfo
         XftTextExtentsUtf8(this.display, font, runeAddr, rune.size, glyph.addr)
-        let centerY = font.ascent + (this.area.height.int - font.height) div 2
-        xLoc -= glyph.xOff
-        XftDrawStringUtf8(
-          this.draw,
-          color.unsafeAddr,
-          font,
-          xLoc,
-          centerY,
-          runeAddr,
-          rune.size
-        )
-        stringWidth.inc glyph.xOff
+        runeInfo.add((rune, font, glyph))
+        stringWidth += glyph.xOff
+        foundFont = true
         break
+    if rune.int32 != ord('[') and rune.int32 in 0x40..0x7E:
+      parsingCsi = false
+    if not foundFont:
+      var glyph: XGlyphInfo
+      runeInfo.add((rune, nil, glyph))
+
+  parsingCsi = false
+  xLoc = x - stringWidth
+  pos = 0
+  for (rune, font, glyph) in runeInfo:
+    let runeAddr = cast[PFcChar8](str[pos].unsafeAddr)
+    pos += rune.size
+    if rune.int32 == 27:
+      parsingCsi = true
+      parsingSgr = false
+      invalidSgr = false
+      continue
+    if parsingCsi:
+      if parsingSgr:
+        if rune.int32 != ord(';') and rune.int32 notin 0x40..0x7E:
+          currentSgr.add rune
+        else:
+          addSgr()
+      if rune.int32 == ord('['):
+        parsingSgr = true
+        reset sgr
+        continue
+    if not parsingCsi and font != nil:
+      let centerY = font.ascent + (this.area.height.int - font.height) div 2
+      XftDrawRect(this.draw, bgColor.addr, xLoc, 0, glyph.xOff.int, this.area.height.int)
+      XftDrawStringUtf8(
+        this.draw,
+        color.addr,
+        font,
+        xLoc,
+        centerY,
+        runeAddr,
+        rune.size
+      )
+      xLoc += glyph.xOff
+
+    if parsingCsi:
+      if rune.int32 in 0x40..0x7E:
+        parsingCsi = false
+        if parsingSgr:
+          if not invalidSgr:
+            var i = 0
+            while i < sgr.len:
+              var
+                oldColor = color
+                oldBgColor = bgColor
+              if sgr[i] == 0:
+                color = defaultColor
+              elif sgr[i] >= 30 and sgr[i] <= 37:
+                this.configureColor(basicColors[sgr[i] - 30], color)
+              elif sgr[i] >= 40 and sgr[i] <= 47:
+                this.configureColor(basicColors[sgr[i] - 40], bgColor)
+              elif sgr[i] >= 90 and sgr[i] <= 97:
+                this.configureColor(brightColors[sgr[i] - 90], color)
+              elif sgr[i] >= 100 and sgr[i] <= 107:
+                this.configureColor(brightColors[sgr[i] - 100], bgColor)
+              elif sgr.len > i + 2 and sgr[i] in {38, 48} and sgr[i + 1] == 5:
+                if sgr[i] == 38:
+                  this.configureColor(extraColors[sgr[i + 2]], color)
+                else:
+                  this.configureColor(extraColors[sgr[i + 2]], bgColor)
+                i += 2
+              elif sgr.len > i + 4 and sgr[i] in {38, 48} and sgr[i + 1] == 2:
+                if sgr[i] == 38:
+                  this.configureColor((sgr[i + 2] shl 16) or (sgr[i + 3] shl 8) or sgr[i + 4], color)
+                else:
+                  this.configureColor((sgr[i + 2] shl 16) or (sgr[i + 3] shl 8) or sgr[i + 4], bgColor)
+                i += 4
+              if oldColor != color and oldColor != defaultColor:
+                this.freeColor(oldColor.addr)
+              if oldBgColor != bgColor and oldBgColor != this.bgColor:
+                this.freeColor(oldBgColor.addr)
+              inc i
+
+  if color != defaultColor:
+    this.freeColor(color.addr)
+  if bgColor != this.bgColor:
+    this.freeColor(bgColor.addr)
 
   return stringWidth
 


### PR DESCRIPTION
This allows you to set ANSI CSI SGR colours on the fore- and background
of the text that is rendered on the status bar. Both the select from
table and the specifying components individually modes are supported.