### PR TITLE
Added windowTitlePosition config option

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -36,6 +36,7 @@ exec = [
   borderColorUrgent = "#ff5555"
   # Bar settings
   barHeight = 20
+  windowTitlePosition = "center"
   barBackgroundColor = "#282a36"
   barForegroundColor = "#f8f8f2"
   barSelectionColor = "#50fa7b"

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -8,7 +8,8 @@ import
   "../keys/keyutils",
   "../event/xeventmanager",
   "../logger",
-  "../tag"
+  "../tag",
+  "../windowtitleposition"
 
 var configLoc*: string
 
@@ -34,6 +35,7 @@ type
     borderWidth*: uint
   BarSettings* = object
     height*: uint
+    windowTitlePosition*: WindowTitlePosition
     fonts*: seq[string]
     # Hex values
     fgColor*, bgColor*, selectionColor*, urgentColor*: int
@@ -165,6 +167,7 @@ proc populateDefaultMonitorSettings(this: Config, display: PDisplay) =
 
   this.defaultMonitorSettings.barSettings = BarSettings(
       height: 20,
+      windowTitlePosition: wtpCenter,
       fonts: @[
         "monospace:size=10:anialias=false",
         "NotoColorEmoji:size=10:anialias=false"
@@ -291,6 +294,19 @@ proc loadHexValue(this: Config, settingsTable: TomlTableRef, valueName: string):
   return -1
 
 proc populateBarSettings*(this: Config, barSettings: var BarSettings, settingsTable: TomlTableRef) =
+  if settingsTable.hasKey("windowTitlePosition"):
+    let wtpToml = settingsTable["windowTitlePosition"]
+    if wtpToml.kind != TomlValueKind.String:
+      raise newException(Exception, "windowTitlePosition needs to be a string!")
+
+    let windowTitlePosition = wtpToml.stringVal.toLower()
+    if windowTitlePosition == "center" or windowTitlePosition == "centre":
+      barSettings.windowTitlePosition = wtpCenter
+    elif windowTitlePosition == "left":
+      barSettings.windowTitlePosition = wtpLeft
+    else:
+      raise newException(Exception, "windowTitlePosition needs to be: center, centre, or left!")
+
   let bgColor = this.loadHexValue(settingsTable, "barBackgroundColor")
   if bgColor != -1:
     barSettings.bgColor = bgColor

--- a/src/nimdowpkg/windowtitleposition.nim
+++ b/src/nimdowpkg/windowtitleposition.nim
@@ -1,0 +1,3 @@
+type WindowTitlePosition* = enum
+  wtpLeft, wtpCenter
+


### PR DESCRIPTION
`windowTitlePosition` can be set to `center`, `centre`, or `left`.

Resolves #115 

I've decided right-aligning the title would be kind of weird, so I didn't include it. If it's specifically requested in the future, I'll add it in.