### PR TITLE
fix addition due to missing culong conversion

### DIFF
--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -170,7 +170,7 @@ proc configureBar(this: StatusBar) =
   var strut: Strut
   strut.top = this.area.height
   strut.topStartX = this.area.x.culong
-  strut.topEndX = strut.topStartX + this.currentWidth - 1
+  strut.topEndX = strut.topStartX + this.currentWidth.culong - 1
 
   discard XChangeProperty(
     this.display,


### PR DESCRIPTION
I just stumbled over this when finally trying out `nimdow`. I suppose this is some sort of regression due to a change on Nim devel? I just pulled Nim's devel about 3 h ago.

The error is a bit confusing too:
```
nimdow/src/nimdowpkg/statusbar.nim(173, 35) Error: ambiguous call; both system.+(x: uint32, y: uint32) [proc declared in /home/basti/src/nim/nim_git_repo/lib/system/arithmetics.nim(373, 6)] and system.+(x: int32, y: int32) [proc declared in /home/basti/src/nim/nim_git_repo/lib/system/arithmetics.nim(182, 6)] match for: (culong, int)
```
Neither of those should really match the arguments. I'm surprised this compiled fine before though, because `Strut` contains only `culong` and `currendWidth` is an `int`. 

The conversion of `currendWidth` seems safe to me, as I imagine that `currendWidth` cannot be negative, right? I thought about converting everything to `int` and then the result to `culong`, but didn't want to have multiple conversions.


Aside from that: took me a few months to finally give Nimdow a try, but I love it so far!