### PR TITLE
Num master windows config option

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -142,16 +142,21 @@ exec = [
   keys = [ "1", "2", "3", "4", "5", "6", "7", "8", "9" ]
   modifiers = [ "super", "shift", "control" ]
 
-[monitors]
-  [monitors.default.tags]
-  all.numMasterWindows = 3
+# Example monitor settings:
+# [monitors]
+  # [monitors.default.tags]
+  # 1.displayString = "one"
+  # 2.displayString = "foobar"
+  # Set the number of master windows for ALL monitors.
+  # all.numMasterWindows = 2
 
-  1.displayString = "one"
-  2.displayString = "foobar"
+  # [monitors.1.tags]
+  # 2.displayString = "two"
+  # Set the number of master windows per-monitor.
+  # all.numMasterWindows = 3
+  # Set the number of master windows per-tag.
+  # 2.numMasterWindows = 1
 
-  [monitors.1.tags]
-  2.displayString = "two"
-
-  [monitors.2.tags]
-  2.displayString = "too"
+  # [monitors.2.tags]
+  # 2.displayString = "too"
 

--- a/config.default.toml
+++ b/config.default.toml
@@ -143,12 +143,12 @@ exec = [
   modifiers = [ "super", "shift", "control" ]
 
 [monitors]
-  [monitors.default]
+  [monitors.default.tags]
   # TODO: have `all` for the tags table.
-  tags.all.numMasterWindows = 2
+  all.numMasterWindows = 2
 
-  tags.1.displayString = "one"
-  tags.2.displayString = "foobar"
+  1.displayString = "one"
+  2.displayString = "foobar"
 
   [monitors.1.tags]
   2.displayString = "two"

--- a/config.default.toml
+++ b/config.default.toml
@@ -144,8 +144,7 @@ exec = [
 
 [monitors]
   [monitors.default.tags]
-  # TODO: have `all` for the tags table.
-  all.numMasterWindows = 2
+  all.numMasterWindows = 3
 
   1.displayString = "one"
   2.displayString = "foobar"

--- a/config.default.toml
+++ b/config.default.toml
@@ -142,3 +142,17 @@ exec = [
   keys = [ "1", "2", "3", "4", "5", "6", "7", "8", "9" ]
   modifiers = [ "super", "shift", "control" ]
 
+[monitors]
+  [monitors.default]
+  # TODO: have `all` for the tags table.
+  tags.all.numMasterWindows = 2
+
+  tags.1.displayString = "one"
+  tags.2.displayString = "foobar"
+
+  [monitors.1.tags]
+  2.displayString = "two"
+
+  [monitors.2.tags]
+  2.displayString = "too"
+

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -12,7 +12,6 @@ import
   ../keys/keyutils,
   ../event/xeventmanager,
   ../logger,
-  ../tag,
   ../windowtitleposition
 
 var configLoc*: string
@@ -179,7 +178,7 @@ proc populateDefaultMonitorSettings(this: Config, display: PDisplay) =
       urgentColor: 0xef2f27
   )
 
-  this.defaultMonitorSettings.tagSettings = createDefaultTagSettings(tagCount)
+  this.defaultMonitorSettings.tagSettings = createDefaultTagSettings()
 
 proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDisplay) =
   this.populateDefaultMonitorSettings(display)
@@ -201,7 +200,7 @@ proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDis
       let tagsTable = changedDefaults["tags"]
       if tagsTable.kind == TomlValueKind.Table:
         # this.defaultMonitorSettings.populateTagSettings(tagsTable.tableVal, display)
-        this.defaultMonitorSettings.tagSettings = populateTagSettings(tagsTable.tableVal)
+        this.defaultMonitorSettings.tagSettings.populateTagSettings(tagsTable.tableVal)
 
   # Populate settings per-monitor
   for monitorIDStr, settingsToml in monitorsTable.tableVal.pairs():
@@ -225,7 +224,7 @@ proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDis
     if settingsToml.hasKey("tags"):
       let tagsTable = settingsToml["tags"]
       if tagsTable.kind == TomlValueKind.Table:
-        monitorSettings.tagSettings = populateTagSettings(tagsTable.tableVal)
+        monitorSettings.tagSettings.populateTagSettings(tagsTable.tableVal)
 
     this.monitorSettings[monitorID] = monitorSettings
 

--- a/src/nimdowpkg/config/tagsettings.nim
+++ b/src/nimdowpkg/config/tagsettings.nim
@@ -32,17 +32,18 @@ proc parseTagSetting(tagSetting: var TagSetting, settingsTable: TomlTableRef) =
     tagSetting.numMasterWindows = numMasterWindows.intVal.int
 
 proc populateTagSettings*(settings: var TagSettings, tagSettingsTable: TomlTableRef) =
-  var allTagSettings: TagSetting = nil
-
   if tagSettingsTable.hasKey("all"):
     let allTagSettingsTable = tagSettingsTable["all"]
     if allTagSettingsTable.kind != TomlValueKind.Table:
       raise newException(Exception, "Settings table incorrect type for tag ID: all")
-    allTagSettings = newTagSetting("", 9999)
+    var allTagSettings = newTagSetting("", int.high)
     allTagSettings.parseTagSetting(allTagSettingsTable.tableVal)
 
     for setting in settings.mvalues:
-      setting = deepCopy allTagSettings
+      if allTagSettings.displayString.len > 0:
+        setting.displayString = allTagSettings.displayString
+      if allTagSettings.numMasterWindows != int.high:
+        setting.numMasterWindows = allTagSettings.numMasterWindows
 
   for tagIDstr, settingsToml in tagSettingsTable.pairs():
     if settingsToml.kind != TomlValueKind.Table:

--- a/src/nimdowpkg/config/tagsettings.nim
+++ b/src/nimdowpkg/config/tagsettings.nim
@@ -16,25 +16,41 @@ proc createUniformTagSettings*(displayString: string, numMasterWindows: Positive
   for i in 1..tagCount:
     result[i] = newTagSetting(displayString, numMasterWindows)
 
-proc parseTagSetting(settingsTable: TomlTable): TagSetting =
+proc parseTagSetting(tagSetting: var TagSetting, settingsTable: TomlTableRef) =
   # Check for displayString
   if settingsTable.hasKey("displayString"):
     let displayString = settingsTable["displayString"]
     if displayString.kind != TomlValueKind.String:
       raise newException(Exception, "Invalid displayString for tag")
-    result.displayString = displayString.stringVal
+    tagSetting.displayString = displayString.stringVal
 
   # Check for numMasterWindows
   if settingsTable.hasKey("numMasterWindows"):
     let numMasterWindows = settingsTable["numMasterWindows"]
     if numMasterWindows.kind != TomlValueKind.Int:
       raise newException(Exception, "Invalid numMasterWindows for tag")
-    result.numMasterWindows = numMasterWindows.intVal.int
+    tagSetting.numMasterWindows = numMasterWindows.intVal.int
 
 proc populateTagSettings*(settings: var TagSettings, tagSettingsTable: TomlTableRef) =
+  var allTagSettings: TagSetting = nil
+
+  if tagSettingsTable.hasKey("all"):
+    let allTagSettingsTable = tagSettingsTable["all"]
+    if allTagSettingsTable.kind != TomlValueKind.Table:
+      raise newException(Exception, "Settings table incorrect type for tag ID: all")
+    allTagSettings = newTagSetting("", 9999)
+    allTagSettings.parseTagSetting(allTagSettingsTable.tableVal)
+
+    for setting in settings.mvalues:
+      setting = deepCopy allTagSettings
+
   for tagIDstr, settingsToml in tagSettingsTable.pairs():
     if settingsToml.kind != TomlValueKind.Table:
       raise newException(Exception, "Settings table incorrect type for tag ID: " & tagIDstr)
+
+    # Special case ignored.
+    if tagIDstr == "all":
+      continue
 
     # Parse the tag ID.
     var tagID: int
@@ -45,18 +61,5 @@ proc populateTagSettings*(settings: var TagSettings, tagSettingsTable: TomlTable
 
     let currentTagSettingsTable = settingsToml.tableVal
     var currentTagSettings: TagSetting = settings[tagID]
-
-    # Check for displayString
-    if currentTagSettingsTable.hasKey("displayString"):
-      let displayString = currentTagSettingsTable["displayString"]
-      if displayString.kind != TomlValueKind.String:
-        raise newException(Exception, "Invalid displayString for tag: " & tagIDstr)
-      currentTagSettings.displayString = displayString.stringVal
-
-    # Check for numMasterWindows
-    if currentTagSettingsTable.hasKey("numMasterWindows"):
-      let numMasterWindows = currentTagSettingsTable["numMasterWindows"]
-      if numMasterWindows.kind != TomlValueKind.Int:
-        raise newException(Exception, "Invalid numMasterWindows for tag: " & tagIDstr)
-      currentTagSettings.numMasterWindows = numMasterWindows.intVal.int
+    currentTagSettings.parseTagSetting(currentTagSettingsTable)
 

--- a/src/nimdowpkg/config/tagsettings.nim
+++ b/src/nimdowpkg/config/tagsettings.nim
@@ -1,0 +1,45 @@
+import
+  parsetoml,
+  strutils
+
+import
+  ../tag
+
+const tableName = "monitors"
+
+type
+  TagSettings* = OrderedTable[TagID, TagSetting]
+
+proc createDefaultTagSettings*(tagCount: Positive): TagSettings =
+  for i in 1..tagCount:
+    result[i] = TagSetting(displayString: $i)
+
+proc populateTagSettings*(tagSettingsTable: TomlTableRef): TagSettings =
+  for tagIDstr, settingsToml in tagSettingsTable.pairs():
+    if settingsToml.kind != TomlValueKind.Table:
+      raise newException(Exception, "Settings table incorrect type for tag ID: " & tagIDstr)
+
+    # Parse the tag ID.
+    var tagID: int
+    try:
+      tagID = parseInt(tagIDstr)
+    except:
+      raise newException(Exception, "Invalid tag id: " & tagIDstr)
+
+    let currentTagSettingsTable = settingsToml.tableVal
+    var currentTagSettings: TagSetting = result[tagID]
+
+    # Check for displayString
+    if currentTagSettingsTable.hasKey("displayString"):
+      let displayString = currentTagSettingsTable["displayString"]
+      if displayString.kind != TomlValueKind.String:
+        raise newException(Exception, "Invalid displayString for tag: " & tagIDstr)
+      currentTagSettings.displayString = displayString.stringVal
+
+    # Check for numMasterWindows
+    if currentTagSettingsTable.hasKey("numMasterWindows"):
+      let numMasterWindows = currentTagSettingsTable["numMasterWindows"]
+      if numMasterWindows.kind != TomlValueKind.Int:
+        raise newException(Exception, "Invalid numMasterWindows for tag: " & tagIDstr)
+      currentTagSettings.numMasterWindows = numMasterWindows.intVal
+

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -9,6 +9,7 @@ type
     monitorArea*: Area
     gapSize*: uint
     borderWidth*: uint
+    masterSlots*: uint
   LayoutOffset* = tuple[top, left, bottom, right: uint]
 
 proc newLayout*(name: string, monitorArea: Area, gapSize: uint, borderWidth: uint): Layout =

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -12,7 +12,6 @@ converter intToCUint(x: int): cuint = x.cuint
 const layoutName: string = "masterstack"
 
 type MasterStackLayout* = ref object of Layout
-  masterSlots*: uint
 
 proc layoutSingleClient(
   this: MasterStackLayout,

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -71,13 +71,14 @@ proc newMonitor*(
 
   result.taggedClients = newTaggedClients(tagCount)
   for i in 1..tagCount:
+    let tagSetting = result.monitorSettings.tagSettings[i]
     let tag: Tag = newTag(
       id = i,
       layout = newMasterStackLayout(
         monitorArea = area,
         gapSize = currentConfig.windowSettings.gapSize,
         borderWidth = currentConfig.windowSettings.borderWidth,
-        masterSlots = masterSlots
+        masterSlots = tagSetting.numMasterWindows.uint
       )
     )
     result.taggedClients.tags.add(tag)
@@ -140,9 +141,11 @@ proc setConfig*(this: Monitor, config: Config) =
   else:
     this.monitorSettings = config.defaultMonitorSettings
 
-  for tag in this.tags:
+  for i, tag in this.tags:
+    let tagSetting = this.monitorSettings.tagSettings[i + 1]
     tag.layout.gapSize = this.windowSettings.gapSize
     tag.layout.borderWidth = this.windowSettings.borderWidth
+    tag.layout.masterSlots = tagSetting.numMasterWindows.uint
 
   this.layoutOffset = (this.monitorSettings.barSettings.height, 0.uint, 0.uint, 0.uint)
   this.statusBar.setConfig(this.monitorSettings.barSettings, this.monitorSettings.tagSettings)

--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -13,7 +13,8 @@ import
   strut,
   logger,
   windowtitleposition,
-  config/configloader
+  config/configloader,
+  config/tagsettings
 
 converter XBoolToBool(x: XBool): bool = bool(x)
 converter boolToXBool(x: bool): XBool = x.XBool

--- a/src/nimdowpkg/taginfo.nim
+++ b/src/nimdowpkg/taginfo.nim
@@ -4,4 +4,5 @@ type
   TagID* = 1..tagCount
   TagSetting* = ref object
     displayString*: string
+    numMasterWindows*: int
 

--- a/src/nimdowpkg/taginfo.nim
+++ b/src/nimdowpkg/taginfo.nim
@@ -4,5 +4,8 @@ type
   TagID* = 1..tagCount
   TagSetting* = ref object
     displayString*: string
-    numMasterWindows*: int
+    numMasterWindows*: Positive
+
+proc newTagSetting*(displayString: string, numMasterWindows: Positive): TagSetting =
+  TagSetting(displayString: displayString, numMasterWindows: numMasterWindows)
 

--- a/tests/nimdowpkg/config/tagsettings_test.nim
+++ b/tests/nimdowpkg/config/tagsettings_test.nim
@@ -26,16 +26,21 @@ test "valid all tags table":
   [all]
   displayString = "[]"
   numMasterWindows = 2
+
+  [7]
+  displayString = "Seven"
+  numMasterWindows = 3
   """
 
   var settings = createDefaultTagSettings()
   let toml = parseString(testToml)
   populateTagSettings(settings, toml.tableVal)
 
-
   for i in 1 .. tagCount:
-    assert settings[i].displayString == "[]"
-    assert settings[i].numMasterWindows == 2
-
-
+    if i == 7:
+      assert settings[i].displayString == "Seven"
+      assert settings[i].numMasterWindows == 3
+    else:
+      assert settings[i].displayString == "[]"
+      assert settings[i].numMasterWindows == 2
 

--- a/tests/nimdowpkg/config/tagsettings_test.nim
+++ b/tests/nimdowpkg/config/tagsettings_test.nim
@@ -1,0 +1,41 @@
+import
+  tag,
+  config/tagsettings,
+  parsetoml
+
+test "valid tags table":
+  let testToml: string = """
+  [1]
+  displayString = "one"
+  numMasterWindows = 2
+  """
+
+  var settings = createDefaultTagSettings()
+  let toml = parseString(testToml)
+  populateTagSettings(settings, toml.tableVal)
+
+  assert settings[1].displayString == "one"
+  assert settings[1].numMasterWindows == 2
+
+  for i in 2 .. tagCount:
+    assert settings[i].displayString == $i
+    assert settings[i].numMasterWindows == 1
+
+test "valid all tags table":
+  let testToml: string = """
+  [all]
+  displayString = "[]"
+  numMasterWindows = 2
+  """
+
+  var settings = createDefaultTagSettings()
+  let toml = parseString(testToml)
+  populateTagSettings(settings, toml.tableVal)
+
+
+  for i in 1 .. tagCount:
+    assert settings[i].displayString == "[]"
+    assert settings[i].numMasterWindows == 2
+
+
+


### PR DESCRIPTION
Resolves #128 

The config file now allows for `numMasterWindows` to be specified.

This option sets the default number of master windows,
which can be set per-tag and per-monitor.

There is an example in the configuration file:

```toml [monitors]
  [monitors.default.tags]
  # Set the number of master windows for ALL monitors.
  all.numMasterWindows = 2

  [monitors.1.tags]
  # Set the number of master windows per-monitor.
  all.numMasterWindows = 3
  # Set the number of master windows per-tag. This overrides the `all` option.
  2.numMasterWindows = 1

  [monitors.2.tags]
  1.numMasterWindows = 4
```