### PR TITLE
`state` added to appRule.

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -6,6 +6,7 @@
 # title = ""
 # monitor = 1
 # tags = [ 1, 4, 7 ]
+# state = "floating" # normal, floating, and fullscreen are all valid.
 
 # Start external programs
 [[startProcess]]

--- a/config.default.toml
+++ b/config.default.toml
@@ -1,12 +1,12 @@
 # App Rules
 # Example:
-# [[appRule]]
-# class = "Element"
-# instance = ""
-# title = ""
-# monitor = 1
-# tags = [ 1, 4, 7 ]
-# state = "floating" # normal, floating, and fullscreen are all valid.
+[[appRule]]
+class = "st"
+instance = "st"
+title = "st"
+monitor = 1
+tags = [ 1, 4, 7 ]
+state = "normal" # normal, floating, and fullscreen are all valid.
 
 # Start external programs
 [[startProcess]]

--- a/config.default.toml
+++ b/config.default.toml
@@ -6,7 +6,7 @@ instance = "st"
 title = "st"
 monitor = 1
 tags = [ 1, 4, 7 ]
-state = "normal" # normal, floating, and fullscreen are all valid.
+state = "floating" # normal, floating, and fullscreen are all valid.
 
 # Start external programs
 [[startProcess]]

--- a/src/nimdowpkg/config/apprules.nim
+++ b/src/nimdowpkg/config/apprules.nim
@@ -7,12 +7,18 @@ import ../taginfo
 const tableName = "appRule"
 const globChar = '*'
 
-type AppRule* = ref object
-  title*: string
-  class*: string
-  instance*: string
-  monitorID*: Positive
-  tagIDs*: seq[TagID]
+type
+  WindowState* = enum
+    wsNormal = "normal",
+    wsFloating = "floating",
+    wsFullscreen = "fullscreen"
+  AppRule* = ref object
+    title*: string
+    class*: string
+    instance*: string
+    monitorID*: Positive
+    tagIDs*: seq[TagID]
+    state*: WindowState
 
 proc newAppRule*(): AppRule =
   AppRule(
@@ -20,7 +26,8 @@ proc newAppRule*(): AppRule =
     class: "",
     instance: "",
     monitorID: 1,
-    tagIDs: @[]
+    tagIDs: @[],
+    state: wsNormal
   )
 
 proc getStringProperty(appRuleTable: TomlTableRef, property: string): string =
@@ -92,6 +99,7 @@ proc parseAppRules*(table: TomlTable): seq[AppRule] =
     appRule.instance= appRuleTable.getStringProperty("instance")
     appRule.monitorID = appRuleTable.getMonitorID()
     appRule.tagIDs = appRuleTable.getTagIDs()
+    appRule.state = parseEnum[WindowState](appRuleTable.getStringProperty("state").toLower(), wsNormal)
     result.add(appRule)
 
 proc globMatches*(str, sub: string): bool =

--- a/src/nimdowpkg/config/apprules.nim
+++ b/src/nimdowpkg/config/apprules.nim
@@ -16,7 +16,7 @@ type
     title*: string
     class*: string
     instance*: string
-    monitorID*: Positive
+    monitorID*: int
     tagIDs*: seq[TagID]
     state*: WindowState
 
@@ -38,11 +38,10 @@ proc getStringProperty(appRuleTable: TomlTableRef, property: string): string =
       raise newException(Exception, property & " must be a string!")
     return prop.stringVal
 
-proc getMonitorID(appRuleTable: TomlTableRef): Positive =
-  result = 1
+proc getMonitorID(appRuleTable: TomlTableRef): int =
   const propertyName = "monitor"
   if not appRuleTable.hasKey(propertyName):
-    raise newException(Exception, propertyName & " must be provided!")
+    return -1
 
   let monitorIDToml = appRuleTable[propertyName]
   if monitorIDToml.kind != TomlValueKind.Int:
@@ -52,12 +51,12 @@ proc getMonitorID(appRuleTable: TomlTableRef): Positive =
   if monitorID < 1:
     raise newException(Exception, propertyName & " must be a positive integer!")
 
-  return monitorID
+  return monitorID.int
 
 proc getTagIDs(appRuleTable: TomlTableRef): seq[TagID] =
   const propertyName = "tags"
   if not appRuleTable.hasKey(propertyName):
-    raise newException(Exception, propertyName & " must be provided!")
+    return @[]
 
   let tagIDsToml = appRuleTable[propertyName]
   if tagIDsToml.kind != TomlValueKind.Array:

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -114,20 +114,21 @@ template clientSelection*(this: Monitor): seq[Client] =
   this.taggedClients.clientSelection
 
 proc updateWindowBorders(this: Monitor) =
+  let currClient: Client = this.taggedClients.currClient
   for n in this.taggedClients.currClientsIter:
     let client = n.value
-    if not client.isUrgent:
+    if not client.isUrgent and client != currClient:
       discard XSetWindowBorder(
         this.display,
         n.value.window,
         this.windowSettings.borderColorUnfocused
       )
 
-  this.taggedClients.withSomeCurrClient(c):
-    if not c.isFixed and not c.isFullscreen:
+  if currClient != nil:
+    if not currClient.isFixed and not currClient.isFullscreen:
       discard XSetWindowBorder(
         this.display,
-        c.window,
+        currClient.window,
         this.windowSettings.borderColorFocused
       )
 

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -385,6 +385,8 @@ proc addClient*(this: Monitor, client: var Client, assignToSelectedTags: bool = 
     client.tagIDs.clear()
     this.toggleSelectedTagsForClient(client)
 
+  this.statusBar.redraw()
+
 proc moveClientToTag*(this: Monitor, client: Client, destinationTagID: TagID) =
   if client.tagIDs.len == 1 and destinationTagID in client.tagIDs:
     return

--- a/src/nimdowpkg/taggedclients.nim
+++ b/src/nimdowpkg/taggedclients.nim
@@ -38,6 +38,10 @@ iterator currClientsIter*(this: TaggedClients): ClientNode {.inline, closure.} =
     if node.value.tagIDs.anyIt(this.selectedTags.contains(it)):
       yield node
 
+func currClientsLen*(this: TaggedClients): int =
+  for c in this.currClientsIter:
+    inc result
+
 iterator currClientsReverseIter*(this: TaggedClients): ClientNode {.inline, closure.} =
   ## Iterates over clients in reverse stack order.
   for node in this.clients.reverseNodes:

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1106,7 +1106,8 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
   client.needsResize = false
 
   this.setClientState(client, NormalState)
-  client.adjustToState(this.display)
+  if monitor.taggedClients.currClientsContains(window):
+    client.adjustToState(this.display)
 
   if appRule != nil and appRule.state == wsFullscreen:
     if monitor.taggedClients.currClientsContains(window):

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1052,17 +1052,20 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
 
   this.setClientState(client, NormalState)
 
-
-  if monitor == this.selectedMonitor:
-    if appRule != nil and appRule.state == wsFullscreen:
-      monitor.setFullscreen(client, true)
-    elif not client.isFixed:
-      monitor.doLayout(false)
+  if appRule != nil and appRule.state == wsFullscreen:
     if monitor.taggedClients.currClientsContains(window):
-      monitor.focusClient(client, not client.isFloating)
+      monitor.setFullscreen(client, true)
+    else:
+      client.isFullscreen = true
+  elif not client.isFixed and monitor.taggedClients.currClientsContains(window):
+    monitor.doLayout(false)
 
   discard XMapWindow(this.display, window)
   client.hasBeenMapped = true
+
+  if monitor == this.selectedMonitor and
+    monitor.taggedClients.currClientsContains(window):
+      monitor.focusClient(client, not client.isFloating or client.isFullscreen)
 
 proc onMapRequest(this: WindowManager, e: XMapRequestEvent) =
   var windowAttr: XWindowAttributes

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1106,6 +1106,7 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
   client.needsResize = false
 
   this.setClientState(client, NormalState)
+  client.adjustToState(this.display)
 
   if appRule != nil and appRule.state == wsFullscreen:
     if monitor.taggedClients.currClientsContains(window):
@@ -1113,18 +1114,15 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
     else:
       client.isFullscreen = true
   elif not client.isFixed and not client.isFloating and monitor.taggedClients.currClientsContains(window):
-    monitor.doLayout(false, monitor == this.selectedMonitor)
+    monitor.doLayout(false, not client.isFloating)
 
   discard XMapWindow(this.display, window)
   client.hasBeenMapped = true
 
   if monitor == this.selectedMonitor and monitor.taggedClients.currClientsContains(window):
-    log "focusing " & $window
     let shouldWarp = not client.isFloating or monitor.taggedClients.currClientsLen == 1
     this.focus(client, shouldWarp)
     monitor.focusClient(client, not client.isFloating or client.isFullscreen)
-
-  client.adjustToState(this.display)
 
 proc onMapRequest(this: WindowManager, e: XMapRequestEvent) =
   var windowAttr: XWindowAttributes

--- a/tests/nimdowpkg/config/apprules_test.nim
+++ b/tests/nimdowpkg/config/apprules_test.nim
@@ -28,6 +28,28 @@ test "valid multiple app rules":
   instance = "element"
   monitor = 2
   tags = [ 1, 9 ]
+  state = "Fullscreen"
+
+  [[appRule]]
+  class = "st"
+  instance = "st"
+  monitor = 1
+  tags = [ 3, 7, 8 ]
+  state = "FLOATING"
+
+  [[appRule]]
+  class = "st"
+  instance = "st"
+  monitor = 1
+  tags = [ 3, 7, 8 ]
+  state = "normal"
+
+  [[appRule]]
+  class = "st"
+  instance = "st"
+  monitor = 1
+  tags = [ 3, 7, 8 ]
+  state = "fooBAR"
 
   [[appRule]]
   class = "st"
@@ -39,19 +61,42 @@ test "valid multiple app rules":
   let toml = parseString(testToml)
   let rules: seq[AppRule] = parseAppRules(toml.tableVal[])
 
-  assert rules.len == 2
+  assert rules.len == 5
 
   let firstRule = rules[0]
   doAssert firstRule.class == "Element"
   doAssert firstRule.instance == "element"
   doAssert firstRule.monitorID == 2.Positive
   doAssert firstRule.tagIDs == @[ 1.TagID, 9 ]
+  doAssert firstRule.state == wsFullscreen
 
   let secondRule = rules[1]
   doAssert secondRule.class == "st"
   doAssert secondRule.instance == "st"
   doAssert secondRule.monitorID == 1.Positive
   doAssert secondRule.tagIDs == @[ 3.TagID, 7, 8 ]
+  doAssert secondRule.state == wsFloating
+
+  let thirdRule = rules[2]
+  doAssert thirdRule.class == "st"
+  doAssert thirdRule.instance == "st"
+  doAssert thirdRule.monitorID == 1.Positive
+  doAssert thirdRule.tagIDs == @[ 3.TagID, 7, 8 ]
+  doAssert thirdRule.state == wsNormal
+
+  let fourthRule = rules[3]
+  doAssert fourthRule.class == "st"
+  doAssert fourthRule.instance == "st"
+  doAssert fourthRule.monitorID == 1.Positive
+  doAssert fourthRule.tagIDs == @[ 3.TagID, 7, 8 ]
+  doAssert fourthRule.state == wsNormal
+
+  let fifthRule = rules[4]
+  doAssert fifthRule.class == "st"
+  doAssert fifthRule.instance == "st"
+  doAssert fifthRule.monitorID == 1.Positive
+  doAssert fifthRule.tagIDs == @[ 3.TagID, 7, 8 ]
+  doAssert fifthRule.state == wsNormal
 
 test "no app rules does not raise an exception":
   let testToml: string = ""

--- a/tests/nimdowpkg/config/apprules_test.nim
+++ b/tests/nimdowpkg/config/apprules_test.nim
@@ -6,6 +6,7 @@ import
 test "valid single app rule":
   let testToml: string = """
   [[appRule]]
+  title = "Element | Billybob"
   class = "Element"
   instance = "element"
   monitor = 2
@@ -16,6 +17,7 @@ test "valid single app rule":
   let rules: seq[AppRule] = parseAppRules(toml.tableVal[])
 
   let firstRule = rules[0]
+  doAssert firstRule.title == "Element | Billybob"
   doAssert firstRule.class == "Element"
   doAssert firstRule.instance == "element"
   doAssert firstRule.monitorID == 2.Positive
@@ -24,6 +26,7 @@ test "valid single app rule":
 test "valid multiple app rules":
   let testToml: string = """
   [[appRule]]
+  title = "Element | Foobar"
   class = "Element"
   instance = "element"
   monitor = 2
@@ -64,6 +67,7 @@ test "valid multiple app rules":
   assert rules.len == 5
 
   let firstRule = rules[0]
+  doAssert firstRule.title == "Element | Foobar"
   doAssert firstRule.class == "Element"
   doAssert firstRule.instance == "element"
   doAssert firstRule.monitorID == 2.Positive
@@ -104,6 +108,21 @@ test "no app rules does not raise an exception":
   let toml = parseString(testToml)
   let rules: seq[AppRule] = parseAppRules(toml.tableVal[])
   assert rules.len == 0
+
+test "has an invalid title":
+  let testToml: string = """
+  [[appRule]]
+  title = 9009
+  class = "123"
+  instance = "element"
+  monitor = 2
+  tags = [ 1, 9 ]
+  """
+
+  let toml = parseString(testToml)
+  assertRaises(Exception, "title must be a string!"):
+    discard parseAppRules(toml.tableVal[])
+
 
 test "has an invalid class":
   let testToml: string = """


### PR DESCRIPTION
Closes #131

In an `appRule`, a `state` for the window can be set.

```toml
[[appRule]]
class = "xlunch-windowed"
state = "fullscreen" # "normal", "floating", and "fullscreen" are all valid.
```

@PMunch If you want to test this build (since I did this PR per your request), let me know how it goes.
I'll do more manual testing this week.

@dakyskye  as well