### PR TITLE
IPC Fix: Default to /tmp if XDG_RUNTIME_DIR is not available.

### DIFF
--- a/src/nimdowpkg/ipc/ipc.nim
+++ b/src/nimdowpkg/ipc/ipc.nim
@@ -9,7 +9,7 @@ import ../logger
 const ipcPrefix* = "nimdow-ipc"
 
 let
-  runtimeDir = getEnv("XDG_RUNTIME_DIR")
+  runtimeDir = if existsEnv("XDG_RUNTIME_DIR"): getEnv("XDG_RUNTIME_DIR") else: "/tmp"
   socketDir = fmt"{runtimeDir}/nimdow"
   pid = getCurrentProcessId()
   socketLoc = fmt"{socketDir}/ipc-socket.{pid}"


### PR DESCRIPTION
There's probably a more compact way to check this, but I like the verbosity ;)