### PR TITLE
Fixed incorrect x and y for XConfigureWindow.

### DIFF
--- a/src/nimdowpkg/client.nim
+++ b/src/nimdowpkg/client.nim
@@ -74,11 +74,11 @@ proc configure*(this: Client, display: PDisplay) =
   event.height = this.height
   event.border_width = this.borderWidth
   event.above = None
-  event.override_redirect = 0
+  event.override_redirect = false
   discard XSendEvent(
     display,
     this.window,
-    0,
+    false,
     StructureNotifyMask,
     cast[PXEvent](event.addr)
   )

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -757,8 +757,8 @@ proc onConfigureRequest(this: WindowManager, e: XConfigureRequestEvent) =
       client.configure(this.display)
   else:
     var changes: XWindowChanges
-    changes.x = e.x - this.selectedMonitor.area.x
-    changes.y = e.y - this.selectedMonitor.area.y
+    changes.x = e.x
+    changes.y = e.y
     changes.width = e.width
     changes.height = e.height
     changes.border_width = e.border_width


### PR DESCRIPTION
This fixes the issue with steam's focus when not started on the primary monitor.

Closes #139 

@dakyskye if you have time to test this I'd appreciate it. It works, just want to make sure it doesn't have any adverse side effects...