### PR TITLE
Require nim v1.4, or later

### DIFF
--- a/nimdow.nimble
+++ b/nimdow.nimble
@@ -8,7 +8,7 @@ installExt    = @["nim"]
 bin           = @["nimdow"]
 
 # Deps
-requires "nim >= 1.2.0"
+requires "nim >= 1.4.0"
 requires "x11"
 requires "parsetoml"
 


### PR DESCRIPTION
Super trivial, I know.

The use of `std/exitprocs` since 32cedd04 requires a more recent nim version.

Thanks,

James
