### PR TITLE
Clickable status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ In short, there's a bug in the xft library most distros use.
 
 If using an Arch Linux based distro, there is [libxft-bgra-git](https://aur.archlinux.org/packages/libxft-bgra-git/) in the AUR.
 
+### Clicking the status bar
+
+The status bar can be clicked. Clicking on any of the tags moves to that tag, similar to using the keyboard shortcut to go to that tag.
+
+Clicking the window title or the status can start a process in the same way keyboard shortcuts can. Simply create a `startProcess` entry with a `clickRegion` key enumerating the region you want the process to be run for. The first region with index 0 is the window title, and the following regions are regions in the user set status. To split the status into regions simly insert the ASCII unit separator special character (`0x1F`). If no regions are added this way the entire status will be region 1. Processes that are started in this way can also take arguments. There are six available arguments that will replace any percentage sign followed by a number in the command. `%0` can be used to get all arguments separated by spaces. The six arguments are:
+`%1` - the index of the printable character in the string, starting from 0
+`%2` - the x coordinate of the region that was clicked
+`%3` - the y coordinate of the region that was clicked
+`%4` - the x coordinate the click occured on
+`%5` - the y coordinate the click occured on
+`%6` - the width of the region that was clicked
+
 ## Issues with Java Applications
 
 ### The fix

--- a/config.default.toml
+++ b/config.default.toml
@@ -29,6 +29,19 @@ command = "st"
 keys = [ "Return" ]
 modifiers = [ "super" ]
 
+# Start process when region is clicked, see documentation for what constitutes a region
+[[startProcess]]
+command = "notify-send \"Id: %1, rx: %2, cx: %4, w: %6\""
+clickRegion = 0
+
+[[startProcess]]
+command = "notify-send \"Id: %1, rx: %2, cx: %4, w: %6\""
+clickRegion = 1
+
+[[startProcess]]
+command = "notify-send \"Id: %1, rx: %2, cx: %4, w: %6\""
+clickRegion = 2
+
 [autostart]
 exec = [
   "xsetroot -cursor_name left_ptr",

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -286,8 +286,10 @@ proc populateExternalProcessSettings(this: Config, configTable: TomlTable, displ
       if commandDeclaration.tableVal["clickRegion"].kind != TomlValueKind.Int:
         raise newException(Exception, "Invalid \"startProcess\" configuration: \"clickRegion\" not a number!")
       let clickRegion = commandDeclaration.tableVal["clickRegion"].intVal.int
-      this.regionClickActionTable[clickRegion] = proc(idx: int, width: int, regionCord: tuple[x, y: int], clickCord: tuple[x, y: int]) =
-        this.runCommandWithArgs(command, $idx, $regionCord.x, $regionCord.y, $clickCord.x, $clickCord.y, $width)
+      closureScope:
+        let command = command
+        this.regionClickActionTable[clickRegion] = proc(idx: int, width: int, regionCord: tuple[x, y: int], clickCord: tuple[x, y: int]) =
+          this.runCommandWithArgs(command, $idx, $regionCord.x, $regionCord.y, $clickCord.x, $clickCord.y, $width)
     else:
       this.configureExternalProcess(command)
       this.populateControlAction(

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1667,6 +1667,11 @@ proc handleButtonPressed(this: WindowManager, e: XButtonEvent) =
     # Clicked systray window, don't do anything.
     return
 
+  for monitor in this.monitors.values:
+    if e.window == monitor.statusBar.barWindow:
+      handleButtonPressed(monitor.statusBar, e)
+      break
+
   # Need to not change mouse state if e.state is not the mod key.
   case e.button:
     of Button1:

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1669,8 +1669,15 @@ proc handleButtonPressed(this: WindowManager, e: XButtonEvent) =
 
   for monitor in this.monitors.values:
     if e.window == monitor.statusBar.barWindow:
-      handleButtonPressed(monitor.statusBar, e)
-      break
+      let clickedInfo = getClickedRegion(monitor.statusBar, e)
+      if clickedInfo.region == -1: return # Nothing was clicked
+      if clickedInfo.region in 0..<monitor.statusBar.tagSettings.len:
+        this.goToTag(clickedInfo.region + 1)
+        return
+      let regionId = if clickedInfo.region == monitor.statusBar.tagSettings.len: 0 else: clickedInfo.region - monitor.statusBar.tagSettings.len
+      if this.config.regionClickActionTable.hasKey(regionId):
+        this.config.regionClickActionTable[regionId](clickedInfo.index, clickedInfo.width, clickedInfo.regionCord, clickedInfo.clickCord)
+      return
 
   # Need to not change mouse state if e.state is not the mod key.
   case e.button:


### PR DESCRIPTION
With this the status bar can be clicked! If you click on any of the tags on the top left you simply go to that tag. If you click the window title or the status text it will run a command from the config. If you want to split the status text into regions you can add user segment characters `0x1F`. Then you can run a different script for each clicked region (the window title is region 0). The command that is run can be passed arguments like the index of the character that was clicked, the x/y position of the region, the width of the region, and the x/y position of the actual click. This should allow a lot of cool clickable things. The system can also be extended to allow keyboard shortcuts to trigger a "click" on specific regions, but this is not currently implemented (would be nice if a click action would align a window with the clicked item, then the keyboard shortcut could do the same thing).