### PR TITLE
Added ability to toggle the status bar per monitor

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -190,6 +190,10 @@ exec = [
   keys = [ "r" ]
   modifiers = [ "super" ]
 
+  [controls.toggleStatusBar]
+  keys = [ "b" ]
+  modifiers = [ "super" ]
+
 # Example monitor settings:
 # [monitors]
   # [monitors.default.tags]

--- a/doc/nimdow.1
+++ b/doc/nimdow.1
@@ -163,3 +163,7 @@ Moves the selected window to the scratchpad.
 .TP
 .BR --pop-scratchpad
 Brings back the window most recently added to the scratchpad.
+.
+.TP
+.BR --toggle-statusbar
+Hides or shows the status bar on the selected monitor.

--- a/nimdow.nimble
+++ b/nimdow.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.7.31"
+version = "0.7.32"
 author = "avahe-kellenberger"
 description = "A window manager written in nim"
 license = "GPL v2"

--- a/src/nimdowpkg/ipc/cli.nim
+++ b/src/nimdowpkg/ipc/cli.nim
@@ -11,7 +11,7 @@ import
   ../wmcommands,
   ../logger
 
-const version* = "v0.7.31"
+const version* = "v0.7.32"
 const commit* = getEnv("LATEST_COMMIT")
 
 proc handleWMCommand(commandStr: string): bool =

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -31,6 +31,7 @@ type
     display: PDisplay
     rootWindow: Window
     statusBar*: StatusBar
+    isStatusBarEnabled*: bool
     systray*: Systray
     area*: Area
     config: Config
@@ -98,6 +99,8 @@ proc newMonitor*(
       result.taggedClients,
       result.monitorSettings.tagSettings
     )
+  
+  result.isStatusBarEnabled = true
 
 ########################################################
 #### Helper procs, iterators, templates, and macros ####
@@ -114,6 +117,24 @@ template clients*(this: Monitor): DoublyLinkedList[Client] =
 
 template clientSelection*(this: Monitor): seq[Client] =
   this.taggedClients.clientSelection
+
+proc enableStatusBar*(this: Monitor) =
+  this.layoutOffset = (this.statusBar.area.height, 0.uint, 0.uint, 0.uint)
+  this.statusBar.show()
+  this.isStatusBarEnabled = true
+  this.doLayout()
+
+proc disableStatusBar*(this: Monitor) =
+  this.layoutOffset = (0.uint, 0.uint, 0.uint, 0.uint)
+  this.statusBar.hide()
+  this.isStatusBarEnabled = false
+  this.doLayout()
+
+proc toggleStatusBar*(this: Monitor) =
+  if this.isStatusBarEnabled:
+    this.disableStatusBar()
+  else:
+    this.enableStatusBar()
 
 proc updateWindowBorders(this: Monitor) =
   let currClient: Client = this.taggedClients.currClient
@@ -306,7 +327,8 @@ proc doLayout*(this: Monitor, warpToClient, focusCurrClient: bool = true) =
 
   if topmostFullscreenClient == nil:
     # There are no fullscreen clients on viewable tags.
-    this.statusBar.show()
+    if this.isStatusBarEnabled:
+      this.statusBar.show()
     for client in this.clients.mitems:
       if client.tagIDs.anyIt(this.selectedTags.contains(it)):
         client.show(this.display)
@@ -319,7 +341,10 @@ proc doLayout*(this: Monitor, warpToClient, focusCurrClient: bool = true) =
       # Only show the topmost fullscreen client.
       if client.window != topmostFullscreenClient.window:
         client.hide(this.display)
-    this.statusBar.hide()
+
+    if this.isStatusBarEnabled:
+      this.statusBar.hide()
+
     if this.systray != nil:
       this.systray.hide(this.display, this.area)
     this.focusClient(topmostFullscreenClient, true)

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -121,12 +121,16 @@ template clientSelection*(this: Monitor): seq[Client] =
 proc enableStatusBar*(this: Monitor) =
   this.layoutOffset = (this.statusBar.area.height, 0.uint, 0.uint, 0.uint)
   this.statusBar.show()
+  if this.systray != nil:
+    this.systray.show(this.display, this.area)
   this.isStatusBarEnabled = true
   this.doLayout()
 
 proc disableStatusBar*(this: Monitor) =
   this.layoutOffset = (0.uint, 0.uint, 0.uint, 0.uint)
   this.statusBar.hide()
+  if this.systray != nil:
+    this.systray.hide(this.display, this.area)
   this.isStatusBarEnabled = false
   this.doLayout()
 
@@ -334,7 +338,7 @@ proc doLayout*(this: Monitor, warpToClient, focusCurrClient: bool = true) =
         client.show(this.display)
       else:
         client.hide(this.display)
-    if this.systray != nil:
+    if this.isStatusBarEnabled and this.systray != nil:
       this.systray.show(this.display, this.statusBar.area)
   else:
     for client in this.clients.mitems:
@@ -345,7 +349,7 @@ proc doLayout*(this: Monitor, warpToClient, focusCurrClient: bool = true) =
     if this.isStatusBarEnabled:
       this.statusBar.hide()
 
-    if this.systray != nil:
+    if this.isStatusBarEnabled and this.systray != nil:
       this.systray.hide(this.display, this.area)
     this.focusClient(topmostFullscreenClient, true)
 

--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -32,6 +32,7 @@ type
   StatusBar* = object
     settings: BarSettings
     tagSettings*: OrderedTable[TagID, TagSetting]
+    isHidden: bool
     isMonitorSelected: bool
     status: string
     activeWindowTitle: string
@@ -195,8 +196,9 @@ proc configureBar(this: StatusBar) =
     12
   )
 
-proc show*(this: StatusBar) =
+proc show*(this: var StatusBar) =
   ## Moves the status bar off screen.
+  this.isHidden = false
   discard XMoveWindow(
     this.display,
     this.barWindow,
@@ -204,14 +206,18 @@ proc show*(this: StatusBar) =
     this.area.y
   )
 
-proc hide*(this: StatusBar) =
+proc hide*(this: var StatusBar) =
   ## Moves the status bar off screen.
+  this.isHidden = true
   discard XMoveWindow(
     this.display,
     this.barWindow,
     this.area.width.int * -2,
     this.area.y
   )
+
+proc isHidden*(this: StatusBar): lent bool =
+  this.isHidden
 
 proc resizeForSystray*(this: var StatusBar, systrayWidth: int, redraw: bool = true) =
   this.systrayWidth = systrayWidth

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -760,6 +760,9 @@ proc mapConfigActions*(this: WindowManager) =
   createControl(keyCombo, $wmcRotateclients):
     this.selectedMonitor.rotateClients()
 
+  createControl(keyCombo, $wmcToggleStatusBar):
+    this.selectedMonitor.toggleStatusBar()
+
 proc focus*(this: WindowManager, client: Client, warpToClient: bool) =
   for monitor in this.monitors.values():
     for taggedClient in monitor.taggedClients.clients:

--- a/src/nimdowpkg/wmcommands.nim
+++ b/src/nimdowpkg/wmcommands.nim
@@ -36,6 +36,7 @@ type
     wmcMoveWindowToScratchpad = "movewindowtoscratchpad"
     wmcPopScratchpad = "popscratchpad"
     wmcRotateclients = "rotateclients"
+    wmcToggleStatusBar = "togglestatusbar"
 
 proc parseCommand*(command: string): Option[WMCommand] =
   try:


### PR DESCRIPTION
Currently not an option in the config to enable by default, but the user may use the `--hide-statusbar` command (default to `Super + b`) to show/hide the status bar.