### PR TITLE
Add clicked button as script argument for statusbar

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -31,7 +31,7 @@ modifiers = [ "super" ]
 
 # Example: Start process when region is clicked, see github wiki for what constitutes a region
 # [[startProcess]]
-# command = "notify-send \"Id: %1, rx: %2, cx: %4, w: %6\""
+# command = "notify-send \"Id: %1, rx: %2, cx: %4, cy: %5, w: %6, b: %7\""
 # clickRegion = 0
 
 [autostart]

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -30,7 +30,7 @@ proc findConfigPath*(): string =
 type
   KeyCombo* = tuple[keycode: int, modifiers: int]
   Action* = proc(keyCombo: KeyCombo): void
-  RegionClickAction* = proc(idx: int, width: int, regionCord: Point[int], clickCord: Point[int]): void
+  RegionClickAction* = proc(idx: int, width: int, regionCord: Point[int], clickCord: Point[int], button: int): void
 
   WindowSettings* = object
     tagCount*: uint
@@ -308,7 +308,7 @@ proc populateExternalProcessSettings(this: Config, configTable: TomlTable, displ
       closureScope:
         let command = command
         this.regionClickActionTable[clickRegion] =
-          proc(idx: int, width: int, regionCord: Point[int], clickCord: Point[int]) =
+          proc(idx: int, width: int, regionCord: Point[int], clickCord: Point[int], button: int) =
             this.runCommandWithArgs(
               command,
               $idx,
@@ -316,7 +316,8 @@ proc populateExternalProcessSettings(this: Config, configTable: TomlTable, displ
               $regionCord.y,
               $clickCord.x,
               $clickCord.y,
-              $width
+              $width,
+              $button
             )
     else:
       this.configureExternalProcess(command)

--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -513,6 +513,7 @@ proc renderStringRightAligned(
             while i < sgr.len:
               if sgr[i] == resetCode:
                 color = -1
+                bgColor = -1
                 selectedFont = -1
                 fontErrorLogged = false
               elif sgr[i] >= fontStart and sgr[i] <= fontStop:

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1823,7 +1823,8 @@ proc handleButtonPressed(this: WindowManager, e: XButtonEvent) =
           clickedInfo.index,
           clickedInfo.width,
           clickedInfo.regionCord,
-          clickedInfo.clickCord
+          clickedInfo.clickCord,
+          e.button.int
         )
       return
 


### PR DESCRIPTION
When you click an option in the statusbar the `clickAction` script would run no matter the button pressed (including scrolling). This adds the button number as an argument to the script, so it's possible to check which button was clicked from the script.