### PR TITLE
PiMo layout algorithm

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -59,6 +59,7 @@ exec = [
     "NotoColorEmoji:size=10:antialias=true"
   ]
   # Layout settings
+  layout = "masterstack"
   gapSize = 12
   outerGap = 0
   resizeStep = 10
@@ -129,11 +130,11 @@ exec = [
   keys = [ "period" ]
   modifiers = [ "super", "shift" ]
 
-  [controls.increaseMasterCount]
   keys = [ "z" ]
+  [controls.layout.increaseMasterCount]
   modifiers = [ "super" ]
 
-  [controls.decreaseMasterCount]
+  [controls.layout.decreaseMasterCount]
   keys = [ "x" ]
   modifiers = [ "super" ]
 
@@ -177,11 +178,11 @@ exec = [
   keys = [ "1", "2", "3", "4", "5", "6", "7", "8", "9" ]
   modifiers = [ "super", "shift", "control" ]
 
-	[controls.increaseMasterWidth]
+	[controls.layout.increaseMasterWidth]
 	keys = [ "l" ]
 	modifiers = [ "super" ]
 
-	[controls.decreaseMasterWidth]
+	[controls.layout.decreaseMasterWidth]
 	keys = [ "h" ]
 	modifiers = [ "super" ]
 

--- a/config.default.toml
+++ b/config.default.toml
@@ -130,8 +130,8 @@ exec = [
   keys = [ "period" ]
   modifiers = [ "super", "shift" ]
 
-  keys = [ "z" ]
   [controls.layout.increaseMasterCount]
+  keys = [ "z" ]
   modifiers = [ "super" ]
 
   [controls.layout.decreaseMasterCount]

--- a/nimdow.nimble
+++ b/nimdow.nimble
@@ -16,7 +16,7 @@ requires "safeseq >= 1.0.0"
 
 # Tasks
 task debug, "Create a debug build":
-  exec "nim -o:bin/nimdow --deepcopy:on --linedir:on --debuginfo c src/nimdow.nim"
+  exec "nim -o:bin/nimdow --linedir:on --debuginfo c src/nimdow.nim"
 
 task release, "Build for release":
   exec "./build.sh"

--- a/src/nimdow.nims
+++ b/src/nimdow.nims
@@ -1,0 +1,1 @@
+--deepcopy:on

--- a/src/nimdowpkg/client.nim
+++ b/src/nimdowpkg/client.nim
@@ -263,5 +263,12 @@ proc findPreviousTiled*(clients: openArray[Client], i: int = 0): int =
       client.isNormal and not client.isFloating and not client.isFullscreen
   )
 
+proc getClientsToBeArranged*(clients: seq[Client]): seq[Client] =
+  ## Finds all clients that should be arranged in the layout.
+  ## Some windows are excluded, such as fullscreen windows.
+  for client in clients:
+    if not client.isFullscreen and not client.isFloating and not client.isFixedSize:
+      result.add(client)
+
 proc hash*(this: Client): Hash = !$Hash(this.window)
 

--- a/src/nimdowpkg/config/apprules.nim
+++ b/src/nimdowpkg/config/apprules.nim
@@ -116,6 +116,7 @@ proc parseAppRules*(table: TomlTable): seq[AppRule] =
     appRule.y = appRuleTable.getIntProperty("y", -1)
     appRule.width = appRuleTable.getIntProperty("width")
     appRule.height = appRuleTable.getIntProperty("height")
+    echo appRule[]
     result.add(appRule)
 
 proc globMatches*(str, sub: string): bool =

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -238,6 +238,8 @@ proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDis
       let tagsTable = changedDefaults["tags"]
       if tagsTable.kind == TomlValueKind.Table:
         # this.defaultMonitorSettings.populateTagSettings(tagsTable.tableVal, display)
+        for tag in this.defaultMonitorSettings.tagSettings.mvalues:
+          tag.layoutSettings = deepCopy this.layoutSettings
         this.defaultMonitorSettings.tagSettings.populateTagSettings(tagsTable.tableVal)
 
   # Populate settings per-monitor
@@ -262,6 +264,8 @@ proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDis
     if settingsToml.hasKey("tags"):
       let tagsTable = settingsToml["tags"]
       if tagsTable.kind == TomlValueKind.Table:
+        for tag in monitorSettings.tagSettings.mvalues:
+          tag.layoutSettings = deepCopy this.layoutSettings
         monitorSettings.tagSettings.populateTagSettings(tagsTable.tableVal)
 
     this.monitorSettings[monitorID] = monitorSettings

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -208,10 +208,11 @@ proc populateDefaultMonitorSettings(this: Config, display: PDisplay) =
 
   this.defaultMonitorSettings.tagSettings = createDefaultTagSettings()
 
-proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDisplay) =
-  this.populateDefaultMonitorSettings(display)
   for tag in this.defaultMonitorSettings.tagSettings.mvalues:
     tag.layoutSettings = deepCopy this.layoutSettings
+
+proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDisplay) =
+  this.populateDefaultMonitorSettings(display)
 
   if not configTable.hasKey("monitors"):
     return

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -210,6 +210,8 @@ proc populateDefaultMonitorSettings(this: Config, display: PDisplay) =
 
 proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDisplay) =
   this.populateDefaultMonitorSettings(display)
+  for tag in this.defaultMonitorSettings.tagSettings.mvalues:
+    tag.layoutSettings = deepCopy this.layoutSettings
 
   if not configTable.hasKey("monitors"):
     return
@@ -218,8 +220,6 @@ proc populateMonitorSettings(this: Config, configTable: TomlTable, display: PDis
   if monitorsTable.kind != TomlValueKind.Table:
     raise newException(Exception, "Invalid monitors config table")
 
-  for tag in this.defaultMonitorSettings.tagSettings.mvalues:
-    tag.layoutSettings = deepCopy this.layoutSettings
   # Change default monitor settings.
   if monitorsTable.hasKey("default"):
     let settingsTable = configTable["settings"].tableVal

--- a/src/nimdowpkg/config/tagsettings.nim
+++ b/src/nimdowpkg/config/tagsettings.nim
@@ -4,7 +4,8 @@ import
 
 import
   ../tag,
-  ../logger
+  ../logger,
+  ../layouts/layoutsettings
 
 type
   TagSettings* = OrderedTable[TagID, TagSetting]
@@ -40,6 +41,8 @@ proc parseTagSetting(tagSetting: var TagSetting, settingsTable: TomlTableRef) =
         log "Invalid defaultMasterWidthPercentage, clamped to 10-90%", lvlWarn
     else:
       raise newException(Exception, "invalid defaultMasterWidthPercentage for tag")
+
+  tagSetting.layoutSettings.populateLayoutSettings(settingsTable)
 
 proc populateTagSettings*(settings: var TagSettings, tagSettingsTable: TomlTableRef) =
   if tagSettingsTable.hasKey("all"):

--- a/src/nimdowpkg/config/tagsettings.nim
+++ b/src/nimdowpkg/config/tagsettings.nim
@@ -4,7 +4,6 @@ import
 
 import
   ../tag,
-  ../logger,
   ../layouts/layoutsettings
 
 type
@@ -12,11 +11,7 @@ type
 
 proc createDefaultTagSettings*(): TagSettings =
   for i in 1..tagCount:
-    result[i] = newTagSetting($i, 1, 50)
-
-proc createUniformTagSettings*(displayString: string, numMasterWindows: Positive, defaultMasterWidthPercentage: int): TagSettings =
-  for i in 1..tagCount:
-    result[i] = newTagSetting(displayString, numMasterWindows, defaultMasterWidthPercentage)
+    result[i] = newTagSetting($i)
 
 proc parseTagSetting(tagSetting: var TagSetting, settingsTable: TomlTableRef) =
   # Check for displayString
@@ -26,22 +21,6 @@ proc parseTagSetting(tagSetting: var TagSetting, settingsTable: TomlTableRef) =
       raise newException(Exception, "Invalid displayString for tag")
     tagSetting.displayString = displayString.stringVal
 
-  # Check for numMasterWindows
-  if settingsTable.hasKey("numMasterWindows"):
-    let numMasterWindows = settingsTable["numMasterWindows"]
-    if numMasterWindows.kind != TomlValueKind.Int:
-      raise newException(Exception, "Invalid numMasterWindows for tag")
-    tagSetting.numMasterWindows = numMasterWindows.intVal.int
-
-  if settingsTable.hasKey("defaultMasterWidthPercentage"):
-    let masterWidthSetting = settingsTable["defaultMasterWidthPercentage"]
-    if masterWidthSetting.kind == TomlValueKind.Int:
-      tagSetting.defaultMasterWidthPercentage = masterWidthSetting.intVal.int.clamp(10,90)
-      if tagSetting.defaultMasterWidthPercentage != masterWidthSetting.intVal:
-        log "Invalid defaultMasterWidthPercentage, clamped to 10-90%", lvlWarn
-    else:
-      raise newException(Exception, "invalid defaultMasterWidthPercentage for tag")
-
   tagSetting.layoutSettings.populateLayoutSettings(settingsTable)
 
 proc populateTagSettings*(settings: var TagSettings, tagSettingsTable: TomlTableRef) =
@@ -49,16 +28,8 @@ proc populateTagSettings*(settings: var TagSettings, tagSettingsTable: TomlTable
     let allTagSettingsTable = tagSettingsTable["all"]
     if allTagSettingsTable.kind != TomlValueKind.Table:
       raise newException(Exception, "Settings table incorrect type for tag ID: all")
-    var allTagSettings = newTagSetting("", int.high, 50)
-    allTagSettings.parseTagSetting(allTagSettingsTable.tableVal)
-
     for setting in settings.mvalues:
-      if allTagSettings.displayString.len > 0:
-        setting.displayString = allTagSettings.displayString
-      if allTagSettings.numMasterWindows != int.high:
-        setting.numMasterWindows = allTagSettings.numMasterWindows
-      if allTagSettings.defaultMasterWidthPercentage != 50:
-        setting.defaultMasterWidthPercentage = allTagSettings.defaultMasterWidthPercentage
+      setting.parseTagSetting(allTagSettingsTable.tableVal)
 
   for tagIDstr, settingsToml in tagSettingsTable.pairs():
     if settingsToml.kind != TomlValueKind.Table:

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -1,8 +1,10 @@
 import
   x11/xlib,
-  parsetoml,
   ../client,
-  ../area
+  ../area,
+  layoutsettings
+
+export layoutsettings
 
 type
   Layout* = ref object of RootObj
@@ -12,7 +14,6 @@ type
     borderWidth*: uint
     masterSlots*: uint
   LayoutOffset* = tuple[top, left, bottom, right: uint]
-  LayoutSettings* = ref object of RootObj
 
 method newLayout*(settings: LayoutSettings,
   monitorArea: Area,
@@ -35,11 +36,5 @@ method updateSettings*(
 method arrange*(this: Layout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) {.base.} =
   echo "arrange not implemented for base class"
 
-method parseLayoutCommand*(this: LayoutSettings, command: string): string {.base.} =
-  echo "parseLayoutCommand not implemented for base class"
-
 method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
   echo "availableCommands not implemented for base class"
-
-method populateLayoutSettings*(this: var LayoutSettings, config: TomlTableRef) {.base.} =
-  echo "populateLayoutSettings not implemented for base class"

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -2,16 +2,11 @@ import
   x11 / [x, xlib],
   ../client,
   ../area,
-  layoutsettings
+  layoutsettings,
+  layouttype,
+  ../taggedclients
 
-export layoutsettings
-
-type
-  Layout* = ref object of RootObj
-    name*: string
-    monitorArea*: Area
-    borderWidth*: uint
-  LayoutOffset* = tuple[top, left, bottom, right: uint]
+export layoutsettings, layouttype
 
 method newLayout*(settings: LayoutSettings,
   monitorArea: Area,
@@ -30,5 +25,5 @@ method updateSettings*(
 method arrange*(this: Layout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) {.base.} =
   echo "arrange not implemented for base class"
 
-method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout, display: PDisplay) {.nimcall.}]] {.base.} =
+method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout, display: PDisplay, taggedClients: TaggedClients) {.nimcall.}]] {.base.} =
   echo "availableCommands not implemented for base class"

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -1,5 +1,5 @@
 import
-  x11/xlib,
+  x11 / [x, xlib],
   ../client,
   ../area,
   layoutsettings
@@ -30,5 +30,5 @@ method updateSettings*(
 method arrange*(this: Layout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) {.base.} =
   echo "arrange not implemented for base class"
 
-method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] {.base.} =
+method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout, display: PDisplay) {.nimcall.}]] {.base.} =
   echo "availableCommands not implemented for base class"

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -30,5 +30,5 @@ method updateSettings*(
 method arrange*(this: Layout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) {.base.} =
   echo "arrange not implemented for base class"
 
-method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
+method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] {.base.} =
   echo "availableCommands not implemented for base class"

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -10,16 +10,12 @@ type
   Layout* = ref object of RootObj
     name*: string
     monitorArea*: Area
-    gapSize*: uint
     borderWidth*: uint
-    masterSlots*: uint
   LayoutOffset* = tuple[top, left, bottom, right: uint]
 
 method newLayout*(settings: LayoutSettings,
   monitorArea: Area,
-  defaultWidth: int,
   borderWidth: uint,
-  masterSlots: uint,
   layoutOffset: LayoutOffset): Layout {.base.} =
   echo "newLayout not implemented for base class"
 
@@ -27,9 +23,7 @@ method updateSettings*(
   this: var Layout,
   settings: LayoutSettings,
   monitorArea: Area,
-  defaultWidth: int,
   borderWidth: uint,
-  masterSlots: uint,
   layoutOffset: LayoutOffset) {.base.} =
   echo "updateSettings not implemented for base class"
 

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -1,5 +1,6 @@
 import
   x11/xlib,
+  parsetoml,
   ../client,
   ../area
 
@@ -13,15 +14,32 @@ type
   LayoutOffset* = tuple[top, left, bottom, right: uint]
   LayoutSettings* = ref object of RootObj
 
-proc newLayout*(name: string, monitorArea: Area, gapSize: uint, borderWidth: uint): Layout =
-  Layout(name: name, gapSize: gapSize, borderWidth: borderWidth)
+method newLayout*(settings: LayoutSettings,
+  monitorArea: Area,
+  defaultWidth: int,
+  borderWidth: uint,
+  masterSlots: uint,
+  layoutOffset: LayoutOffset): Layout {.base.} =
+  echo "newLayout not implemented for base class"
+
+method updateSettings*(
+  this: var Layout,
+  settings: LayoutSettings,
+  monitorArea: Area,
+  defaultWidth: int,
+  borderWidth: uint,
+  masterSlots: uint,
+  layoutOffset: LayoutOffset) {.base.} =
+  echo "updateSettings not implemented for base class"
 
 method arrange*(this: Layout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) {.base.} =
-  echo "Not implemented for base class"
+  echo "arrange not implemented for base class"
 
 method parseLayoutCommand*(this: LayoutSettings, command: string): string {.base.} =
-  echo "Not implemented for base class"
+  echo "parseLayoutCommand not implemented for base class"
 
 method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
-  echo "Not implemented for base class"
+  echo "availableCommands not implemented for base class"
 
+method populateLayoutSettings*(this: var LayoutSettings, config: TomlTableRef) {.base.} =
+  echo "populateLayoutSettings not implemented for base class"

--- a/src/nimdowpkg/layouts/layout.nim
+++ b/src/nimdowpkg/layouts/layout.nim
@@ -11,10 +11,17 @@ type
     borderWidth*: uint
     masterSlots*: uint
   LayoutOffset* = tuple[top, left, bottom, right: uint]
+  LayoutSettings* = ref object of RootObj
 
 proc newLayout*(name: string, monitorArea: Area, gapSize: uint, borderWidth: uint): Layout =
   Layout(name: name, gapSize: gapSize, borderWidth: borderWidth)
 
 method arrange*(this: Layout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) {.base.} =
+  echo "Not implemented for base class"
+
+method parseLayoutCommand*(this: LayoutSettings, command: string): string {.base.} =
+  echo "Not implemented for base class"
+
+method availableCommands*(this: LayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
   echo "Not implemented for base class"
 

--- a/src/nimdowpkg/layouts/layouts.nim
+++ b/src/nimdowpkg/layouts/layouts.nim
@@ -4,11 +4,13 @@ import
 
 export options
 
-import layout, masterstacklayout
+import layout, masterstacklayout, pimo
 
 proc parseLayoutSetting*(command: string): Option[LayoutSettings] =
   case command.toLower:
   of "masterstack":
     some(MasterStackLayoutSettings().LayoutSettings())
+  of "pimo":
+    some(PimoLayoutSettings().LayoutSettings())
   else:
     none[LayoutSettings]()

--- a/src/nimdowpkg/layouts/layouts.nim
+++ b/src/nimdowpkg/layouts/layouts.nim
@@ -1,0 +1,14 @@
+import
+  options,
+  strutils
+
+export options
+
+import layout, masterstacklayout
+
+proc parseLayoutSetting*(command: string): Option[LayoutSettings] =
+  case command.toLower:
+  of "masterstack":
+    some(MasterStackLayoutSettings().LayoutSettings())
+  else:
+    none[LayoutSettings]()

--- a/src/nimdowpkg/layouts/layoutsettings.nim
+++ b/src/nimdowpkg/layouts/layoutsettings.nim
@@ -1,0 +1,10 @@
+import parsetoml
+
+type
+  LayoutSettings* = ref object of RootObj
+
+method parseLayoutCommand*(this: LayoutSettings, command: string): string {.base.} =
+  echo "parseLayoutCommand not implemented for base class"
+
+method populateLayoutSettings*(this: var LayoutSettings, config: TomlTableRef) {.base.} =
+  echo "populateLayoutSettings not implemented for base class"

--- a/src/nimdowpkg/layouts/layouttype.nim
+++ b/src/nimdowpkg/layouts/layouttype.nim
@@ -1,0 +1,9 @@
+import ../area
+
+type
+  Layout* = ref object of RootObj
+    name*: string
+    monitorArea*: Area
+    borderWidth*: uint
+  LayoutOffset* = tuple[top, left, bottom, right: uint]
+

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -188,14 +188,13 @@ method updateSettings*(
     settings: LayoutSettings,
     monitorArea: Area,
     borderWidth: uint,
-    masterSlots: uint,
     layoutOffset: LayoutOffset) =
   let masterStackSettings = cast[MasterStackLayoutSettings](settings)
   this.monitorArea = monitorArea
   this.gapSize = masterStackSettings.gapSize
   this.defaultWidth = masterStackSettings.defaultMasterWidthPercentage
   this.borderWidth = borderWidth
-  this.masterSlots = masterSlots
+  this.masterSlots = masterStackSettings.numMasterWindows
   this.outerGap = masterStackSettings.outerGap
   this.setDefaultWidth(layoutOffset)
 

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -1,5 +1,5 @@
 import
-  x11/xlib,
+  x11/[x, xlib],
   parsetoml,
   strutils,
   math,
@@ -119,10 +119,10 @@ method populateLayoutSettings*(this: var MasterStackLayoutSettings, settingsTabl
     else:
       raise newException(Exception, "invalid defaultMasterWidthPercentage for tag")
 
-proc increaseMasterCount(layout: Layout) =
+proc increaseMasterCount(layout: Layout, _: PDisplay) =
   MasterStackLayout(layout).masterSlots.inc
 
-proc decreaseMasterCount(layout: Layout) =
+proc decreaseMasterCount(layout: Layout, _: PDisplay) =
   var masterStackLayout = MasterStackLayout(layout)
   if masterStackLayout.masterSlots.int > 0:
     masterStackLayout.masterSlots.dec
@@ -137,13 +137,13 @@ template modWidthDiff(layout: Layout, diff: int) =
         diff).int > 0:
       masterStackLayout.widthDiff += diff
 
-proc increaseMasterWidth(layout: Layout) =
+proc increaseMasterWidth(layout: Layout, _: PDisplay) =
   layout.modWidthDiff(layout.MasterStackLayout.resizeStep.int)
 
-proc decreaseMasterWidth(layout: Layout) =
+proc decreaseMasterWidth(layout: Layout, _: PDisplay) =
   layout.modWidthDiff(-layout.MasterStackLayout.resizeStep.int)
 
-method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
+method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout, display: PDisplay) {.nimcall.}]] =
   result = @[
     ($mscIncreaseMasterWidth, increaseMasterWidth),
     ($mscDecreaseMasterWidth, decreaseMasterWidth),

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -6,7 +6,8 @@ import
   layout,
   ../client,
   ../area,
-  ../logger
+  ../logger,
+  ../taggedclients
 
 converter intToCint(x: int): cint = x.cint
 converter intToCUint(x: int): cuint = x.cuint
@@ -119,10 +120,10 @@ method populateLayoutSettings*(this: var MasterStackLayoutSettings, settingsTabl
     else:
       raise newException(Exception, "invalid defaultMasterWidthPercentage for tag")
 
-proc increaseMasterCount(layout: Layout, _: PDisplay) =
+proc increaseMasterCount(layout: Layout, _: PDisplay, _: TaggedClients) =
   MasterStackLayout(layout).masterSlots.inc
 
-proc decreaseMasterCount(layout: Layout, _: PDisplay) =
+proc decreaseMasterCount(layout: Layout, _: PDisplay, _: TaggedClients) =
   var masterStackLayout = MasterStackLayout(layout)
   if masterStackLayout.masterSlots.int > 0:
     masterStackLayout.masterSlots.dec
@@ -137,13 +138,13 @@ template modWidthDiff(layout: Layout, diff: int) =
         diff).int > 0:
       masterStackLayout.widthDiff += diff
 
-proc increaseMasterWidth(layout: Layout, _: PDisplay) =
+proc increaseMasterWidth(layout: Layout, _: PDisplay, _: TaggedClients) =
   layout.modWidthDiff(layout.MasterStackLayout.resizeStep.int)
 
-proc decreaseMasterWidth(layout: Layout, _: PDisplay) =
+proc decreaseMasterWidth(layout: Layout, _: PDisplay, _: TaggedClients) =
   layout.modWidthDiff(-layout.MasterStackLayout.resizeStep.int)
 
-method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout, display: PDisplay) {.nimcall.}]] =
+method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout, display: PDisplay, taggedClients: TaggedClients) {.nimcall.}]] =
   result = @[
     ($mscIncreaseMasterWidth, increaseMasterWidth),
     ($mscDecreaseMasterWidth, decreaseMasterWidth),

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -21,6 +21,7 @@ type
     outerGap*: uint
     offset: LayoutOffset
     masterSlots*: uint
+    resizeStep*: uint
   MasterStackLayoutSettings* = ref object of LayoutSettings
     gapSize*: uint
     outerGap*: uint
@@ -138,10 +139,10 @@ template modWidthDiff(layout: Layout, diff: int) =
       masterStackLayout.widthDiff += diff
 
 proc increaseMasterWidth(layout: Layout) {.gcsafe.} =
-  layout.modWidthDiff(10)#this.selectedMonitor.monitorSettings.layoutSettings.resizeStep.int)
+  layout.modWidthDiff(layout.MasterStackLayout.resizeStep.int)
 
 proc decreaseMasterWidth(layout: Layout) {.gcsafe.} =
-  layout.modWidthDiff(-10)#-this.selectedMonitor.monitorSettings.layoutSettings.resizeStep.int)
+  layout.modWidthDiff(-layout.MasterStackLayout.resizeStep.int)
 
 method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
   result = @[
@@ -158,6 +159,7 @@ proc newMasterStackLayout*(
   borderWidth: uint,
   masterSlots: uint,
   layoutOffset: LayoutOffset,
+  resizeStep: uint,
   outerGap: uint = 0
 ): MasterStackLayout =
   ## Creates a new MasterStack layout.
@@ -170,16 +172,16 @@ proc newMasterStackLayout*(
     borderWidth: borderWidth,
     masterSlots: masterSlots,
     outerGap: outerGap,
-    offset: layoutOffset
+    offset: layoutOffset,
+    resizeStep: resizeStep
   )
   result.setDefaultWidth(layoutOffset)
 
 method newLayout*(settings: MasterStackLayoutSettings,
     monitorArea: Area,
-    #defaultWidth: int,
     borderWidth: uint,
     layoutOffset: LayoutOffset): Layout =
-  newMasterStackLayout(monitorArea, settings.gapSize, settings.defaultMasterWidthPercentage, borderWidth, settings.numMasterWindows, layoutOffset, settings.outerGap)
+  newMasterStackLayout(monitorArea, settings.gapSize, settings.defaultMasterWidthPercentage, borderWidth, settings.numMasterWindows, layoutOffset, settings.outerGap, settings.resizeStep)
 
 method updateSettings*(
     this: var MasterStackLayout,

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -61,7 +61,7 @@ proc calcYPosition(
   clientHeight: uint,
   roundingError: int
 ): uint
-proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint {.gcsafe.}
+proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint
 func calcScreenWidth*(this: MasterStackLayout, offset: LayoutOffset): int
 func calcScreenHeight*(this: MasterStackLayout, offset: LayoutOffset): int
 proc getClientsToBeArranged(clients: seq[Client]): seq[Client]
@@ -138,10 +138,10 @@ template modWidthDiff(layout: Layout, diff: int) =
         diff).int > 0:
       masterStackLayout.widthDiff += diff
 
-proc increaseMasterWidth(layout: Layout) {.gcsafe.} =
+proc increaseMasterWidth(layout: Layout) =
   layout.modWidthDiff(layout.MasterStackLayout.resizeStep.int)
 
-proc decreaseMasterWidth(layout: Layout) {.gcsafe.} =
+proc decreaseMasterWidth(layout: Layout) =
   layout.modWidthDiff(-layout.MasterStackLayout.resizeStep.int)
 
 method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
@@ -375,7 +375,7 @@ proc calcYPosition(
 
   return max(0, pos).uint
 
-proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint {.gcsafe.} =
+proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint =
   ## client width per pane excluding borders & gaps
   let outerGap =
     if this.outerGap > 0:

--- a/src/nimdowpkg/layouts/masterstacklayout.nim
+++ b/src/nimdowpkg/layouts/masterstacklayout.nim
@@ -51,7 +51,7 @@ proc layoutMultipleClients(
   offset: LayoutOffset
 )
 
-proc setDefaultWidth*(this: MasterStackLayout, offset: LayoutOffset)
+proc setDefaultWidth(this: MasterStackLayout, offset: LayoutOffset)
 proc calculateClientHeight(this: MasterStackLayout, clientsInColumn: uint, screenHeight: uint): uint
 proc calcRoundingErr(this: MasterStackLayout, clientsInColumn, clientHeight, screenHeight: uint): int
 proc calcYPosition(
@@ -61,10 +61,9 @@ proc calcYPosition(
   clientHeight: uint,
   roundingError: int
 ): uint
-proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint
-func calcScreenWidth*(this: MasterStackLayout, offset: LayoutOffset): int
-func calcScreenHeight*(this: MasterStackLayout, offset: LayoutOffset): int
-proc getClientsToBeArranged(clients: seq[Client]): seq[Client]
+proc calcClientWidth(this: MasterStackLayout, screenWidth: uint): uint
+func calcScreenWidth(this: MasterStackLayout, offset: LayoutOffset): int
+func calcScreenHeight(this: MasterStackLayout, offset: LayoutOffset): int
 
 method parseLayoutCommand*(this: MasterStackLayoutSettings, command: string): string =
   try:
@@ -152,7 +151,7 @@ method availableCommands*(this: MasterStackLayoutSettings): seq[tuple[command: s
     ($mscDecreaseMasterCount, decreaseMasterCount)
   ]
 
-proc newMasterStackLayout*(
+proc newMasterStackLayout(
   monitorArea: Area,
   gapSize: uint,
   defaultWidth: int,
@@ -312,7 +311,7 @@ proc layoutMultipleClients(
       clientHeight
     )
 
-proc setDefaultWidth*(this: MasterStackLayout, offset: LayoutOffset) =
+proc setDefaultWidth(this: MasterStackLayout, offset: LayoutOffset) =
   let screenWidth = calcScreenWidth(this, offset)
   let pxPercent = math.round(screenWidth.float / 100).int
   this.widthDiff = (this.defaultWidth - 50) * pxPercent
@@ -374,7 +373,7 @@ proc calcYPosition(
 
   return max(0, pos).uint
 
-proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint =
+proc calcClientWidth(this: MasterStackLayout, screenWidth: uint): uint =
   ## client width per pane excluding borders & gaps
   let outerGap =
     if this.outerGap > 0:
@@ -390,12 +389,5 @@ proc calcClientWidth*(this: MasterStackLayout, screenWidth: uint): uint =
           math.round(this.gapSize.float * 0.5).int
   )
 
-proc getClientsToBeArranged(clients: seq[Client]): seq[Client] =
-  ## Finds all clients that should be arranged in the layout.
-  ## Some windows are excluded, such as fullscreen windows.
-  for client in clients:
-    if not client.isFullscreen and not client.isFloating and not client.isFixedSize:
-      result.add(client)
-
-func calcScreenWidth*(this: MasterStackLayout, offset: LayoutOffset): int = this.monitorArea.width.int - offset.left.int - offset.right.int
-func calcScreenHeight*(this: MasterStackLayout, offset: LayoutOffset): int = this.monitorArea.height.int - offset.top.int - offset.bottom.int
+func calcScreenWidth(this: MasterStackLayout, offset: LayoutOffset): int = this.monitorArea.width.int - offset.left.int - offset.right.int
+func calcScreenHeight(this: MasterStackLayout, offset: LayoutOffset): int = this.monitorArea.height.int - offset.top.int - offset.bottom.int

--- a/src/nimdowpkg/layouts/pimo.nim
+++ b/src/nimdowpkg/layouts/pimo.nim
@@ -1,0 +1,465 @@
+import
+  x11 / [x, xlib],
+  parsetoml,
+  strutils,
+  sequtils,
+  math,
+  layout,
+  ../client,
+  ../area,
+  ../logger,
+  pimo/areatools
+import std/algorithm except shuffle
+
+converter intToCint(x: int): cint = x.cint
+converter intToCUint(x: int): cuint = x.cuint
+
+const layoutName: string = "pimo"
+
+type
+  TrackedClient = ref object
+    client: Client
+    requested: Area
+    expandX: bool
+    expandY: bool
+  Solution = object
+    dir1, dir2: Direction
+    bounding: Area
+    solution: seq[Area]
+    newPosition: Area
+    overlaps: seq[TrackedClient]
+    overlapX: int
+    overlapY: int
+  Path = object
+    requested: uint
+    path: seq[TrackedClient]
+  PimoLayout* = ref object of Layout
+    offset: LayoutOffset
+    trackedClients: seq[TrackedClient]
+  PimoLayoutSettings* = ref object of LayoutSettings
+    gapSize*: uint
+    outerGap*: uint
+    resizeStep*: uint
+    numMasterWindows*: uint
+    defaultMasterWidthPercentage*: int
+  Commands = enum
+    mscIncreaseMasterCount = "increasemastercount",
+    mscDecreaseMasterCount = "decreasemastercount",
+    mscIncreaseMasterWidth = "increasemasterwidth",
+    mscDecreaseMasterWidth = "decreasemasterwidth",
+
+proc shuffle(this: PimoLayout, dir: Direction): bool {.discardable.} =
+  let clients = this.trackedClients
+  generalizeForDirection(dir)
+  let limit = this.dimensionSize
+  var
+    placed: seq[TrackedClient]
+    sortedEdge =
+      if towardsStart: clients.sortedByIt(it.client.area.startEdge)
+      else: clients.sortedByIt(limit.int - (it.client.area.endEdge))
+  for edge in sortedEdge:
+    let square = edge.client.area
+    var closestEdge =
+      if towardsStart: this.offsetStart.int
+      else: limit.int - square.size.int + this.offsetEnd.int
+    for placedEdge in placed:
+      let placed = placedEdge.client.area
+      if square.sameDir(placed):
+        closestEdge =
+          if towardsStart: max(closestEdge, placed.endEdge)
+          else: min(closestEdge, placed.startEdge - square.size.int)
+    result = result or square.startEdge != closestEdge.cint# - 1
+    if dir in {Left, Right}:
+      edge.client.area.x = closestEdge# - 1
+    else:
+      edge.client.area.y = closestEdge# - 1
+    placed.add edge
+
+proc shuffle(this: PimoLayout, d1, d2: Direction) =
+  var moved = true
+  while moved:
+    moved = this.shuffle(d1) and moved
+    moved = this.shuffle(d2) and moved
+
+proc calcBounding(squares: seq[TrackedClient]): Area =
+  if squares.len == 0:
+    return
+  result = squares[0].client.area
+  result.width += result.x.uint
+  result.height += result.y.uint
+  for i in squares.low+1..squares.high:
+    result.x = min(squares[i].client.area.x, result.x)
+    result.y = min(squares[i].client.area.y, result.y)
+    result.width = max(squares[i].client.area.x.uint + squares[i].client.area.width, result.width)
+    result.height = max(squares[i].client.area.y.uint + squares[i].client.area.height, result.height)
+  result.width -= result.x.uint
+  result.height -= result.y.uint
+
+proc testSolution(this: PimoLayout, newSquare: TrackedClient, dir1, dir2: Direction): Solution =
+  result.dir1 = dir1
+  result.dir2 = dir2
+  this.shuffle(dir1, dir2)
+  if dir1 == Left or dir2 == Left:
+    newSquare.client.area.x = this.monitorArea.width.int - this.offset.right.int - newSquare.client.area.width.int
+  else:
+    newSquare.client.area.x = this.offset.left.int
+  if dir1 == Up or dir2 == Up:
+    newSquare.client.area.y = this.monitorArea.height.int - this.offset.bottom.int - newSquare.client.area.height.int
+  else:
+    newSquare.client.area.y = this.offset.top.int
+  var overlaps: seq[TrackedClient]
+  for square in this.trackedClients:
+    if collision(square.client.area, newSquare.client.area).area != 0:
+      overlaps.add square
+  let ratio = (this.monitorArea.width.int - this.offset.left.int - this.offset.right.int).float / (this.monitorArea.height.int - this.offset.top.int - this.offset.bottom.int).float
+  if overlaps.len == 0:
+    this.trackedClients.add newSquare
+    var backup = this.trackedClients.mapIt(it.client.area)
+    this.shuffle(dir1, dir2)
+    let b1 = calcBounding(this.trackedClients)
+    #swap(this.trackedClients, backup)
+    for i, client in this.trackedClients.mpairs: swap(client.client.area, backup[i])
+    this.shuffle(dir2, dir1)
+    let b2 = calcBounding(this.trackedClients)
+    if (b1.area == b2.area and abs(b1.width.float / b1.height.float - ratio) <= abs(b2.width.float / b2.height.float - ratio)) or
+       (b1.area < b2.area):
+      result.bounding = b1
+      result.solution = backup
+    else:
+      result.bounding = b2
+      result.solution = this.trackedClients.mapIt(it.client.area)
+    result.newPosition = newSquare.client.area
+    this.trackedClients.del(this.trackedClients.high) # Remove new one again, will be added later
+  else:
+    result.bounding = (x: this.offset.left.int, y: this.offset.top.int, width: this.monitorArea.width - this.offset.left - this.offset.right, height: this.monitorArea.height - this.offset.top - this.offset.bottom)
+    result.overlaps = overlaps
+    result.overlapX = 0
+    result.overlapY = 0
+    for square in overlaps:
+      let col = square.client.area.collision(newSquare.client.area)
+      result.overlapX += col.width.int
+      result.overlapY += col.height.int
+    result.solution = this.trackedClients.mapIt(it.client.area)
+    result.newPosition = newSquare.client.area
+
+proc longestPath(this: PimoLayout, x: TrackedClient, dir: Direction): Path =
+  #echo "Checking ", x
+  let
+    usableWidth = this.monitorArea.width - this.offset.left - this.offset.right
+    usableHeight = this.monitorArea.height - this.offset.top - this.offset.bottom
+  generalizeForDirection(dir)
+  template requestedSize(x: TrackedClient): uint {.inject.} =
+    if dir in {Right, Left}:
+      if x.expandX: usableWidth else: x.requested.width
+    else:
+      if x.expandY: usableHeight else: x.requested.height
+  if towardsStart and x.client.area.startEdge == 0:
+    #echo "Reached end with window ", x.count
+    return Path(requested: x.requestedSize, path: @[x])
+  if towardsEnd and x.client.area.endEdge == (if dir == Right: usableWidth else: usableHeight).int:
+    #echo "Reached end with window ", x.count
+    return Path(requested: x.requestedSize, path: @[x])
+
+  for square in this.trackedClients:
+    if square.client.window == x.client.window: continue
+    #echo square.startEdge, " ", x.endEdge
+    #echo square.endEdge, " ", x.startEdge
+    if (towardsEnd and square.client.area.startEdge == x.client.area.endEdge) or
+       (towardsStart and square.client.area.endEdge == x.client.area.startEdge):
+      #echo "Found square on edge: ", square
+      if square.client.area.sameDir x.client.area:
+        #echo "And it's in the same column/row"
+        let path = this.longestPath(square, dir)
+        if path.requested > result.requested:
+          result = path
+
+  result.requested += x.requestedSize
+  result.path.add x
+
+proc solveConflict(this: PimoLayout, newSquare: TrackedClient, s: Solution) =
+  var
+    hDir, vDir: Direction
+  let
+    usableWidth = this.monitorArea.width - this.offset.left - this.offset.right
+    usableHeight = this.monitorArea.height - this.offset.top - this.offset.bottom
+  if s.dir1 == Left or s.dir2 == Left:
+    newSquare.client.area.x = usableWidth.int - newSquare.client.area.width.int
+    hDir = Left
+  else:
+    newSquare.client.area.x = this.offset.left.int
+    hDir = Right
+  if s.dir1 == Up or s.dir2 == Up:
+    newSquare.client.area.y = usableHeight.int - newSquare.client.area.height.int
+    vDir = Up
+  else:
+    newSquare.client.area.y = this.offset.top.int
+    vDir = Down
+
+  var overlaps = s.overlaps
+
+  while overlaps.len != 0:
+    var
+      dir: Direction
+      path: Path
+    for square in overlaps:
+      let
+        col = square.client.area.collision(newSquare.client.area)
+        cdir = if col.width.float / square.client.area.width.float < col.height.float / square.client.area.height.float: hDir else: vDir
+        cpath = this.longestPath(square, cdir)
+      if cpath.requested > path.requested:
+        path = cpath
+        dir = cdir
+
+    generalizeForDirection(dir)
+    var
+      overflow = path.requested.int + newSquare.client.area.size.int - this.dimensionSize.int
+      correction = overflow div (path.path.len + 1)
+    overflow -= correction
+
+    if dir in {Left, Right}:
+      newSquare.client.area.width -= correction.uint
+      if towardsStart:
+        newSquare.client.area.x += correction
+    else:
+      newSquare.client.area.height -= correction.uint
+      if towardsStart:
+        newSquare.client.area.y += correction
+
+    for i, square in path.path:
+      correction = overflow div (path.path.len - i) # Recalculate each step to avoid remainder
+      overflow -= correction
+      if dir in {Left, Right}:
+        square.client.area.width -= correction.uint
+        if towardsEnd:
+          square.client.area.x += correction
+      else:
+        square.client.area.height -= correction.uint
+        if towardsEnd:
+          square.client.area.y += correction
+
+    this.shuffle(dir)
+
+    overlaps = @[]
+    for square in this.trackedClients:
+      let col = square.client.area.collision(newSquare.client.area)
+      if col.area != 0:
+        overlaps.add square
+
+  this.trackedClients.add newSquare
+  this.shuffle(s.dir1, s.dir2)
+
+proc iterGrow(this: PimoLayout, dir: Direction) =
+  generalizeForDirection(dir)
+  template resize(square: TrackedClient, change: int): untyped =
+    if horizontal:
+      square.client.area.width += change.uint
+      if towardsEnd: square.client.area.x -= change
+    if vertical:
+      square.client.area.height += change.uint
+      if towardsEnd: square.client.area.y -= change
+  template pureRequestedSize(x: TrackedClient): uint =
+    if dir in {Right, Left}: x.requested.width
+    else: x.requested.height
+  template requestedSize(x: TrackedClient): uint {.inject.} =
+    if dir in {Right, Left}:
+      if x.expandX: usableWidth else: x.requested.width
+    else:
+      if x.expandY: usableHeight else: x.requested.height
+  let
+    usableWidth = this.monitorArea.width - this.offset.left - this.offset.right
+    usableHeight = this.monitorArea.height - this.offset.top - this.offset.bottom
+    sortedEdge =
+      if towardsStart: this.trackedClients.sortedByIt(it.client.area.startEdge)
+      else: this.trackedClients.sortedByIt((if dir == Right: usableWidth else: usableHeight).int - it.client.area.endEdge)
+  # TODO; Scale down previously expanded windows as well
+  for square in this.trackedClients:
+    if (horizontal and square.expandX) or (vertical and square.expandY):
+      #stdout.writeLine "Resizing ", square, " from ", square.size
+      square.resize(min(0, square.pureRequestedSize.int - square.client.area.size.int))
+  var resized = true
+  while resized:
+    resized = false
+    var oldPos: Table[Window, int]
+    for square in sortedEdge:
+      if square.requestedSize < square.client.area.size:
+        resized = true
+        square.resize(square.requestedSize.int - square.client.area.size.int)
+      oldPos[square.client.window] = square.client.area.leadingEdge
+    this.shuffle(dir)
+    for square in sortedEdge:
+      if square.requestedSize != square.client.area.size:
+        let change = (abs(square.client.area.leadingEdge - oldPos[square.client.window]) * square.client.area.size.int) div this.dimensionSize().int
+        if change != 0:
+          square.resize(change)
+          resized = true
+    this.shuffle(dir.opposite)
+
+proc iterDistr(this: PimoLayout, dir: Direction) =
+  generalizeForDirection(dir)
+  let
+    usableWidth = this.monitorArea.width - this.offset.left - this.offset.right
+    usableHeight = this.monitorArea.height - this.offset.top - this.offset.bottom
+    sortedEdge =
+      if towardsStart: this.trackedClients.sortedByIt(it.client.area.startEdge)
+      else: this.trackedClients.sortedByIt((if dir == Right: usableWidth else: usableHeight).int - it.client.area.endEdge)
+  var
+    changed = true
+    i = 0
+  while changed:
+    changed = false
+    for square in sortedEdge:
+      var
+        closestEnd = this.dimensionSize.int
+        closestStart = 0
+      for inner in sortedEdge:
+        if inner.client.window == square.client.window: continue
+        if inner.client.area.sameDir(square.client.area):
+          if inner.client.area.endEdge <= square.client.area.startEdge:
+            closestStart = max(closestStart, inner.client.area.endEdge)
+          else:
+            closestEnd = min(closestEnd, inner.client.area.startEdge)
+      let
+        spaceStart = square.client.area.startEdge - closestStart
+        spaceEnd = closestEnd - square.client.area.endEdge
+      if towardsEnd and spaceEnd > spaceStart and (spaceEnd - spaceStart) div 2 != 0:
+        if horizontal: square.client.area.x += (spaceEnd - spaceStart) div 2
+        if vertical: square.client.area.y += (spaceEnd - spaceStart) div 2
+        changed = true
+      if towardsStart and spaceStart > spaceEnd and (spaceStart - spaceEnd) div 2 != 0:
+        if horizontal: square.client.area.x -= (spaceStart - spaceEnd) div 2
+        if vertical: square.client.area.y -= (spaceStart - spaceEnd) div 2
+        changed = true
+    inc i
+
+proc distribLeft(this: PimoLayout) =
+  this.iterGrow(Left)
+  this.iterDistr(Left)
+
+proc distribUp(this: PimoLayout) =
+  this.iterGrow(Up)
+  this.iterDistr(Up)
+
+proc distribRight(this: PimoLayout) =
+  this.iterGrow(Right)
+  this.iterDistr(Right)
+
+proc distribDown(this: PimoLayout) =
+  this.iterGrow(Down)
+  this.iterDistr(Down)
+
+proc addWindow(this: PimoLayout, s: TrackedClient) =
+  proc cmp(x, y: Solution): int =
+    # TODO: Take into account movement length for windows
+    let
+      areaX = x.bounding.area
+      areaY = y.bounding.area
+    if areaX != areaY:
+      return (areaX - areaY).int
+    let
+      ratio = (this.monitorArea.width - this.offset.left - this.offset.right).float / (this.monitorArea.height - this.offset.top - this.offset.bottom).float
+      ratioX = abs(x.bounding.width.float / x.bounding.height.float - ratio)
+      ratioY = abs(y.bounding.width.float / y.bounding.height.float - ratio)
+    if ratioX != ratioY:
+      return (ratioX - ratioY).int
+    let
+      xOverlap = x.overlapX + x.overlapY
+      yOverlap = y.overlapX + y.overlapY
+    if xOverlap != yOverlap:
+      return xOverlap - yOverlap
+    return x.overlaps.len - y.overlaps.len
+
+  #s.client.area = s.requested
+  s.requested = s.client.area
+  var solutions: seq[Solution]
+  let
+    backup = this.trackedClients.mapIt(it.client.area)
+    sBackup = s.client.area
+  template addSolution(d1, d2: Direction): untyped =
+    solutions.add this.testSolution(s, d1, d2)
+    s.client.area = sBackup
+    for i, client in this.trackedClients.mpairs: client.client.area = backup[i]
+  addSolution(Left, Up)
+  addSolution(Up, Left)
+  addSolution(Up, Right)
+  addSolution(Right, Up)
+  addSolution(Left, Down)
+  addSolution(Down, Left)
+  addSolution(Down, Right)
+  addSolution(Right, Down)
+  solutions.sort(cmp)
+  let solution = solutions[0]
+  #if solution.overlap == 0:
+  #this.trackedClients = solution.solution
+  for i, client in this.trackedClients.mpairs: client.client.area = solution.solution[i]
+  s.client.area = solution.newPosition
+  if solution.overlaps.len != 0:
+    echo "Solution has overlaps, solving with new window in position: ", s.client.area
+    this.solveConflict(s, solution)
+  else:
+    this.trackedClients.add s
+  for dir in [solution.dir1, solution.dir2]:
+    case dir:
+    of Left: this.distribRight()
+    of Right: this.distribLeft()
+    of Up: this.distribDown()
+    of Down: this.distribUp()
+
+method newLayout*(settings: PimoLayoutSettings,
+    monitorArea: Area,
+    borderWidth: uint,
+    layoutOffset: LayoutOffset): Layout =
+  PimoLayout(
+    name: layoutName,
+    monitorArea: monitorArea,
+    borderWidth: borderWidth,
+    offset: layoutOffset
+  ).Layout
+
+method updateSettings*(
+  this: var PimoLayout,
+  settings: LayoutSettings,
+  monitorArea: Area,
+  borderWidth: uint,
+  layoutOffset: LayoutOffset) =
+  echo "Updating PiMo layout settings"
+
+method arrange*(this: PimoLayout, display: PDisplay, clients: seq[Client], offset: LayoutOffset) =
+  echo "Arranging by PiMo layout"
+  this.offset = offset
+  var
+    removedClients = this.trackedClients
+    addedClients: seq[TrackedClient]
+  for client in clients:
+    echo client.repr
+    block clientCheck:
+      for i, removed in removedClients:
+        if removed.client.window == client.window:
+          removedClients.del(i)
+          break clientCheck
+      addedClients.add TrackedClient(client: client, requested: client.oldArea, expandX: false, expandY: false)
+  echo "Clients removed: ", removedClients.len
+  echo "Clients added: ", addedClients.len
+  for client in addedClients:
+    #this.trackedClients.add client
+    this.addWindow(client)
+  #this.shuffle(Down, Right)
+  for client in this.trackedClients:
+    client.client.adjustToState(display)
+    echo client.repr
+
+method availableCommands*(this: PimoLayoutSettings): seq[tuple[command: string, action: proc(layout: Layout) {.nimcall.}]] =
+  echo "Reporting available commands"
+  result = @[
+  ]
+
+method parseLayoutCommand*(this: PimoLayoutSettings, command: string): string =
+  echo "Parsing layout commands"
+  return ""
+  try:
+    return $parseEnum[Commands](command.toLower)
+  except:
+    return ""
+
+method populateLayoutSettings*(this: var PimoLayoutSettings, config: TomlTableRef) =
+  echo "Populating PiMo layout settings"
+  discard

--- a/src/nimdowpkg/layouts/pimo.nim
+++ b/src/nimdowpkg/layouts/pimo.nim
@@ -376,12 +376,8 @@ proc addWindow(this: PimoLayout, s: TrackedClient) =
       return xOverlap - yOverlap
     return x.overlaps.len - y.overlaps.len
 
-  #s.client.area = s.requested
   s.requested = s.client.area
-  s.requested.width += s.client.borderWidth * 2 + this.settings.gapSize
-  s.requested.height += s.client.borderWidth * 2 + this.settings.gapSize
-  s.requested.x -= s.client.borderWidth.int + this.settings.gapSize.int div 2
-  s.requested.y -= s.client.borderWidth.int + this.settings.gapSize.int div 2
+
   var solutions: seq[Solution]
   let
     backup = this.trackedClients.mapIt(it.client.area)
@@ -433,10 +429,17 @@ proc see(this: PimoLayout, x: TrackedClient, dir: Direction): seq[TrackedClient]
         result.add square
   this.iterDistr(dir)
 
+proc collapse(this: PimoLayout, dir: Direction) =
+  generalizeForDirection(dir)
+  for square in this.trackedClients:
+    square.client.area.size = 2
+
 proc reDistr(this: PimoLayout, dir1, dir2: Direction) =
+  this.collapse(dir2)
   this.shuffle(dir2)
   this.iterGrow(dir2.opposite)
   this.iterDistr(dir2.opposite)
+  this.collapse(dir1)
   this.shuffle(dir1)
   this.iterGrow(dir1.opposite)
   this.iterDistr(dir1.opposite)
@@ -590,7 +593,6 @@ method arrange*(this: PimoLayout, display: PDisplay, clients: seq[Client], offse
     client.client.area.width -= client.client.borderWidth * 2'u + this.settings.gapSize
     client.client.area.height -= client.client.borderWidth * 2'u + this.settings.gapSize
     client.client.adjustToState(display)
-    #echo client.repr
 
 template expand(layout: Layout, display: PDisplay, dir: untyped): untyped =
   var

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -11,7 +11,6 @@ import
   xatoms,
   area,
   layouts/layout,
-  layouts/masterstacklayout,
   config/configloader,
   keys/keyutils,
   statusbar,
@@ -76,9 +75,9 @@ proc newMonitor*(
         #currentConfig.layoutSettings,
         tagSetting.layoutSettings,
         monitorArea = area,
-        defaultWidth = tagSetting.defaultMasterWidthPercentage,
+        #defaultWidth = tagSetting.defaultMasterWidthPercentage,
         borderWidth = currentConfig.windowSettings.borderWidth,
-        masterSlots = tagSetting.numMasterWindows.uint,
+        #masterSlots = tagSetting.numMasterWindows.uint,
         layoutOffset = result.layoutOffset,
       )
     )
@@ -188,13 +187,10 @@ proc setConfig*(this: Monitor, config: Config) =
     tag.layout.updateSettings(
       tagSetting.layoutSettings,
       this.area,
-      tagSetting.defaultMasterWidthPercentage,
       this.windowSettings.borderWidth,
-      tagSetting.numMasterWindows.uint,
       this.layoutOffset)
 
   for client in this.taggedClients.clients:
-    #if client.borderWidth != 0 or this.monitorSettings.layoutSettings.outerGap > 0:
     client.borderWidth = this.windowSettings.borderWidth
     client.oldBorderWidth = this.windowSettings.borderWidth
     if client.isFloating or client.isFixedSize:
@@ -205,6 +201,7 @@ proc setConfig*(this: Monitor, config: Config) =
 proc updateWindowTitle(this: Monitor, redrawBar: bool = true) =
   ## Renders the title of the active window of the given monitor
   ## on the monitor's status bar.
+  #hello
   let currClient = this.taggedClients.currClient
   var title: string
   if currClient != nil:

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -72,12 +72,9 @@ proc newMonitor*(
     let tag: Tag = newTag(
       id = i,
       layout = newLayout(
-        #currentConfig.layoutSettings,
         tagSetting.layoutSettings,
         monitorArea = area,
-        #defaultWidth = tagSetting.defaultMasterWidthPercentage,
         borderWidth = currentConfig.windowSettings.borderWidth,
-        #masterSlots = tagSetting.numMasterWindows.uint,
         layoutOffset = result.layoutOffset,
       )
     )
@@ -201,7 +198,6 @@ proc setConfig*(this: Monitor, config: Config) =
 proc updateWindowTitle(this: Monitor, redrawBar: bool = true) =
   ## Renders the title of the active window of the given monitor
   ## on the monitor's status bar.
-  #hello
   let currClient = this.taggedClients.currClient
   var title: string
   if currClient != nil:

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -73,7 +73,8 @@ proc newMonitor*(
     let tag: Tag = newTag(
       id = i,
       layout = newLayout(
-        currentConfig.layoutSettings,
+        #currentConfig.layoutSettings,
+        tagSetting.layoutSettings,
         monitorArea = area,
         defaultWidth = tagSetting.defaultMasterWidthPercentage,
         borderWidth = currentConfig.windowSettings.borderWidth,
@@ -185,7 +186,7 @@ proc setConfig*(this: Monitor, config: Config) =
   for i, tag in this.tags:
     let tagSetting = this.monitorSettings.tagSettings[i + 1]
     tag.layout.updateSettings(
-      config.layoutSettings,
+      tagSetting.layoutSettings,
       this.area,
       tagSetting.defaultMasterWidthPercentage,
       this.windowSettings.borderWidth,

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -72,7 +72,6 @@ proc newMonitor*(
     let tagSetting = result.monitorSettings.tagSettings[i]
     let tag: Tag = newTag(
       id = i,
-      # TODO: Call method newLayout with LayoutSettings from config
       layout = newLayout(
         currentConfig.layoutSettings,
         monitorArea = area,

--- a/src/nimdowpkg/monitor.nim
+++ b/src/nimdowpkg/monitor.nim
@@ -72,14 +72,14 @@ proc newMonitor*(
     let tagSetting = result.monitorSettings.tagSettings[i]
     let tag: Tag = newTag(
       id = i,
-      layout = newMasterStackLayout(
+      # TODO: Call method newLayout with LayoutSettings from config
+      layout = newLayout(
+        currentConfig.layoutSettings,
         monitorArea = area,
-        gapSize = result.monitorSettings.layoutSettings.gapSize,
         defaultWidth = tagSetting.defaultMasterWidthPercentage,
         borderWidth = currentConfig.windowSettings.borderWidth,
         masterSlots = tagSetting.numMasterWindows.uint,
         layoutOffset = result.layoutOffset,
-        outerGap = result.monitorSettings.layoutSettings.outerGap
       )
     )
     result.taggedClients.tags.add(tag)
@@ -185,17 +185,17 @@ proc setConfig*(this: Monitor, config: Config) =
 
   for i, tag in this.tags:
     let tagSetting = this.monitorSettings.tagSettings[i + 1]
-    tag.layout.gapSize = this.monitorSettings.layoutSettings.gapSize
-    tag.layout.borderWidth = this.windowSettings.borderWidth
-    tag.layout.masterSlots = tagSetting.numMasterWindows.uint
-    let masterLayout = cast[MasterStackLayout](tag.layout)
-    masterLayout.outerGap = this.monitorSettings.layoutSettings.outerGap
-    masterLayout.defaultWidth = tagSetting.defaultMasterWidthPercentage
-    masterLayout.setDefaultWidth(this.layoutOffset)
+    tag.layout.updateSettings(
+      config.layoutSettings,
+      this.area,
+      tagSetting.defaultMasterWidthPercentage,
+      this.windowSettings.borderWidth,
+      tagSetting.numMasterWindows.uint,
+      this.layoutOffset)
 
   for client in this.taggedClients.clients:
-    if client.borderWidth != 0 or this.monitorSettings.layoutSettings.outerGap > 0:
-      client.borderWidth = this.windowSettings.borderWidth
+    #if client.borderWidth != 0 or this.monitorSettings.layoutSettings.outerGap > 0:
+    client.borderWidth = this.windowSettings.borderWidth
     client.oldBorderWidth = this.windowSettings.borderWidth
     if client.isFloating or client.isFixedSize:
       client.adjustToState(this.display)

--- a/src/nimdowpkg/tag.nim
+++ b/src/nimdowpkg/tag.nim
@@ -1,7 +1,7 @@
 import
   hashes,
   taginfo,
-  layouts/layout
+  layouts/layouttype
 
 export taginfo
 

--- a/src/nimdowpkg/taginfo.nim
+++ b/src/nimdowpkg/taginfo.nim
@@ -1,3 +1,5 @@
+import layouts/layoutsettings
+
 const tagCount* = 9
 
 type
@@ -6,6 +8,7 @@ type
     displayString*: string
     numMasterWindows*: Positive
     defaultMasterWidthPercentage*: int
+    layoutSettings*: LayoutSettings
 
 proc newTagSetting*(displayString: string, numMasterWindows: Positive, defaultMasterWidthPercentage :int): TagSetting =
   TagSetting(displayString: displayString, numMasterWindows: numMasterWindows, defaultMasterWidthPercentage: defaultMasterWidthPercentage)

--- a/src/nimdowpkg/taginfo.nim
+++ b/src/nimdowpkg/taginfo.nim
@@ -6,10 +6,8 @@ type
   TagID* = 1..tagCount
   TagSetting* = ref object
     displayString*: string
-    numMasterWindows*: Positive
-    defaultMasterWidthPercentage*: int
     layoutSettings*: LayoutSettings
 
-proc newTagSetting*(displayString: string, numMasterWindows: Positive, defaultMasterWidthPercentage :int): TagSetting =
-  TagSetting(displayString: displayString, numMasterWindows: numMasterWindows, defaultMasterWidthPercentage: defaultMasterWidthPercentage)
+proc newTagSetting*(displayString: string): TagSetting =
+  TagSetting(displayString: displayString)
 

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -704,12 +704,6 @@ proc mapConfigActions*(this: WindowManager) =
   createControl(keyCombo, $wmcJumpToUrgentWindow):
     this.jumpToUrgentWindow()
 
-  #createControl(keyCombo, $wmcIncreaseMasterWidth):
-  #  this.increaseMasterWidth()
-
-  #createControl(keyCombo, $wmcDecreaseMasterWidth):
-  #  this.decreaseMasterWidth()
-
   createControl(keyCombo, $wmcMoveWindowToScratchpad):
     this.moveWindowToScratchpad()
 

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -1153,17 +1153,17 @@ proc manage(this: WindowManager, window: Window, windowAttr: XWindowAttributes) 
       if appRule.state == wsFloating:
         client.isFloating = true
 
-        # AppRule x and y are default -1 when not set.
-        if appRule.x >= 0:
-          x = appRule.x
-        if appRule.y >= 0:
-          y = appRule.y
+      # AppRule x and y are default -1 when not set.
+      if appRule.x >= 0:
+        x = appRule.x
+      if appRule.y >= 0:
+        y = appRule.y
 
-        # AppRule width and height are default 0 when not set.
-        if appRule.width > 0:
-          width = appRule.width
-        if appRule.height > 0:
-          height = appRule.height
+      # AppRule width and height are default 0 when not set.
+      if appRule.width > 0:
+        width = appRule.width
+      if appRule.height > 0:
+        height = appRule.height
 
     let appRuleDoesNotHaveValidTags = appRule == nil or appRule.tagIDs.len == 0
     monitor.addClient(client, appRuleDoesNotHaveValidTags)

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -723,10 +723,8 @@ proc mapConfigActions*(this: WindowManager) =
     this.selectedMonitor.toggleStatusBar()
 
   for (command, action) in this.config.layoutSettings.availableCommands():
-    echo "Registering command ", command
     capture command, action:
       createControl(keyCombo, command):
-        echo "Hit combination: ", keyCombo
         let firstSelectedTag = this.selectedMonitor.taggedClients.findFirstSelectedTag()
         if firstSelectedTag == nil:
           return

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -133,7 +133,6 @@ proc newWindowManager*(
     result.config = config
     result.config.populateGeneralSettings(configTable)
     result.mapConfigActions()
-    # TODO: Add mapLayoutActions which calls method in layout to register callbacks
     result.config.populateKeyComboTable(configTable, result.display)
     result.config.hookConfig()
     result.grabKeys()
@@ -555,27 +554,6 @@ proc jumpToUrgentWindow(this: WindowManager) =
 
   urgentMonitor.setSelectedTags(tagID)
   this.display.warpTo(urgentClient)
-
-# TODO: Move layoutsettings to layout, re-enable this
-#template modWidthDiff(this: WindowManager, diff: int) =
-#  var layout = this.selectedMonitor.taggedClients.findFirstSelectedTag.layout
-#  if layout of MasterStackLayout:
-#    let masterStackLayout = cast[MasterStackLayout](layout)
-#    let screenWidth = masterStackLayout.calcScreenWidth(this.selectedMonitor.layoutOffset)
-#
-#    if
-#      (diff > 0 and masterStackLayout.widthDiff < 0) or
-#      (diff < 0 and masterStackLayout.widthDiff > 0) or
-#      masterStackLayout.calcClientWidth(screenWidth).int - abs(masterStackLayout.widthDiff).int - abs(
-#          diff).int > 0:
-#        masterStackLayout.widthDiff += diff
-#        this.selectedMonitor.doLayout()
-#
-#proc increaseMasterWidth(this: WindowManager) =
-#  this.modWidthDiff(this.selectedMonitor.monitorSettings.layoutSettings.resizeStep.int)
-#
-#proc decreaseMasterWidth(this: WindowManager) =
-#  this.modWidthDiff(-this.selectedMonitor.monitorSettings.layoutSettings.resizeStep.int)
 
 proc moveWindowToScratchpad(this: WindowManager) =
   var client = this.selectedMonitor.taggedClients.currClient

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -727,7 +727,7 @@ proc mapConfigActions*(this: WindowManager) =
           layout = firstSelectedTag.layout
           window: Window
           reverse: cint
-        action(layout, this.display)
+        action(layout, this.display, this.selectedMonitor.taggedClients)
         this.selectedMonitor.doLayout()
 
 proc focus*(this: WindowManager, client: Client, warpToClient: bool) =

--- a/src/nimdowpkg/windowmanager.nim
+++ b/src/nimdowpkg/windowmanager.nim
@@ -723,8 +723,11 @@ proc mapConfigActions*(this: WindowManager) =
         if firstSelectedTag == nil:
           return
 
-        var layout = firstSelectedTag.layout
-        action(layout)
+        var
+          layout = firstSelectedTag.layout
+          window: Window
+          reverse: cint
+        action(layout, this.display)
         this.selectedMonitor.doLayout()
 
 proc focus*(this: WindowManager, client: Client, warpToClient: bool) =

--- a/src/nimdowpkg/wmcommands.nim
+++ b/src/nimdowpkg/wmcommands.nim
@@ -29,8 +29,6 @@ type
     wmcDestroySelectedWindow = "destroyselectedwindow",
     wmcToggleFloating = "togglefloating",
     wmcJumpToUrgentWindow = "jumptourgentwindow"
-    #wmcIncreaseMasterWidth = "increasemasterwidth"
-    #wmcDecreaseMasterWidth = "decreasemasterwidth"
     wmcMoveWindowToScratchpad = "movewindowtoscratchpad"
     wmcPopScratchpad = "popscratchpad"
     wmcRotateclients = "rotateclients"

--- a/src/nimdowpkg/wmcommands.nim
+++ b/src/nimdowpkg/wmcommands.nim
@@ -7,8 +7,6 @@ export options
 type
   WMCommand* = enum
     wmcReloadConfig = "reloadconfig",
-    wmcIncreaseMasterCount = "increasemastercount",
-    wmcDecreaseMasterCount = "decreasemastercount",
     wmcMoveWindowToPreviousMonitor = "movewindowtopreviousmonitor",
     wmcMoveWindowToNextMonitor = "movewindowtonextmonitor",
     wmcFocusPreviousMonitor = "focuspreviousmonitor",
@@ -31,12 +29,13 @@ type
     wmcDestroySelectedWindow = "destroyselectedwindow",
     wmcToggleFloating = "togglefloating",
     wmcJumpToUrgentWindow = "jumptourgentwindow"
-    wmcIncreaseMasterWidth = "increasemasterwidth"
-    wmcDecreaseMasterWidth = "decreasemasterwidth"
+    #wmcIncreaseMasterWidth = "increasemasterwidth"
+    #wmcDecreaseMasterWidth = "decreasemasterwidth"
     wmcMoveWindowToScratchpad = "movewindowtoscratchpad"
     wmcPopScratchpad = "popscratchpad"
     wmcRotateclients = "rotateclients"
     wmcToggleStatusBar = "togglestatusbar"
+    wmcLayout = "layout"
 
 proc parseCommand*(command: string): Option[WMCommand] =
   try:

--- a/tests/nimdowpkg/config/tagsettings_test.nim
+++ b/tests/nimdowpkg/config/tagsettings_test.nim
@@ -2,6 +2,8 @@ import
   nimtest,
   tag,
   config/tagsettings,
+  layouts/layout,
+  layouts/masterstacklayout,
   parsetoml
 
 describe "Tag settings":
@@ -14,15 +16,18 @@ describe "Tag settings":
     """
 
     var settings = createDefaultTagSettings()
+    for i in 1 .. tagCount:
+      settings[i].layoutSettings = MasterStackLayoutSettings()
+      settings[i].layoutSettings.populateLayoutSettings(nil)
     let toml = parseString(testToml)
     populateTagSettings(settings, toml.tableVal)
 
     assert settings[1].displayString == "one"
-    assert settings[1].numMasterWindows == 2
+    assert settings[1].layoutSettings.MasterStackLayoutSettings.numMasterWindows == 2
 
     for i in 2 .. tagCount:
       assert settings[i].displayString == $i
-      assert settings[i].numMasterWindows == 1
+      assert settings[i].layoutSettings.MasterStackLayoutSettings.numMasterWindows == 1
 
   it "parses a valid [all] tags table":
     let testToml: string = """
@@ -36,14 +41,17 @@ describe "Tag settings":
     """
 
     var settings = createDefaultTagSettings()
+    for i in 1 .. tagCount:
+      settings[i].layoutSettings = MasterStackLayoutSettings()
+      settings[i].layoutSettings.populateLayoutSettings(nil)
     let toml = parseString(testToml)
     populateTagSettings(settings, toml.tableVal)
 
     for i in 1 .. tagCount:
       if i == 7:
         assert settings[i].displayString == "Seven"
-        assert settings[i].numMasterWindows == 3
+        assert settings[i].layoutSettings.MasterStackLayoutSettings.numMasterWindows == 3
       else:
         assert settings[i].displayString == "[]"
-        assert settings[i].numMasterWindows == 2
+        assert settings[i].layoutSettings.MasterStackLayoutSettings.numMasterWindows == 2
 


### PR DESCRIPTION
This is based directly off-of the `layoutrework` branch, so you can go ahead and merge that first and this becomes four commits.

Adds Nimdows first alternative layout, PiMo! PiMo is a non-overlapping window management strategy, similar to tiling window managers but respecting the size requested by the window (or controlled via app rules). Windows are laid out where there is room for them, trying to minimize how much other windows have to change their size. Moving windows around with left/right/up/down movements also tries to be as intuitive as possible. In addition to moving windows, making them float, and making them fullscreen PiMo also supports a couple more actions. Namely "expand X" and "expand Y", these basically tells the window manager that this window should attempt to be as large as possible in the X and/or Y directions. If an app rule is applied to all windows enabling both expansions the experience is similar to that of a tiling window manager, although PiMo will scale the available space based on the windows initial request. This means that if a large window like a browser is put next to a small window like a terminal then the browser will get more than 50% of the available width and the terminal will get slightly less.

Currently this should be in a useable state, however it is missing resizing options at the moment (these are very simple to implement, simply set the requested size and reshuffle the windows). I'm making this PR because I'm likely going to be away for about a week and I figured someone might want to try this out.