### PR TITLE
Add option to set the colour of a tag which has windows on it, and to disable the indicator

### DIFF
--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -45,7 +45,7 @@ type
     fonts*: seq[string]
     showIndicator*: bool
     # Hex values
-    fgColor*, bgColor*, selectionColor*, urgentColor*, hasTagsColor*: int
+    fgColor*, bgColor*, selectionColor*, urgentColor*, hasWindowsColor: int
     transparency*: uint8
   ScratchpadSettings* = object
     width*: int
@@ -209,7 +209,7 @@ proc populateDefaultMonitorSettings(this: Config, display: PDisplay) =
       bgColor: 0x1c1b19,
       selectionColor: 0x519f50,
       urgentColor: 0xef2f27,
-      hasTagsColor: 0xfce8c3
+      hasWindowsColor: 0xfce8c3
   )
 
   this.defaultMonitorSettings.layoutSettings = LayoutSettings(
@@ -408,9 +408,11 @@ proc populateBarSettings*(this: Config, barSettings: var BarSettings, settingsTa
     if barTransparency.kind == TomlValueKind.Int:
       barSettings.transparency = clamp(barTransparency.intVal, 0, 255).uint8
 
-  let hasTagsColor = this.loadHexValue(settingsTable, "barHasTagsColor")
-  if hasTagsColor != -1:
-    barSettings.hasTagsColor = hasTagsColor
+  let hasWindowsColor= this.loadHexValue(settingsTable, "barHasWindowsColor")
+  if hasWindowsColor!= -1:
+    barSettings.hasWindowsColor= hasWindowsColor
+  else:
+    barSettings.hasWindowsColor = fgColor
 
   if settingsTable.hasKey("barShowIndicator"):
     let showIndicator = settingsTable["barShowIndicator"]

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -43,8 +43,9 @@ type
     height*: uint
     windowTitlePosition*: WindowTitlePosition
     fonts*: seq[string]
+    showIndicator*: bool
     # Hex values
-    fgColor*, bgColor*, selectionColor*, urgentColor*: int
+    fgColor*, bgColor*, selectionColor*, urgentColor*, hasTagsColor*: int
     transparency*: uint8
   ScratchpadSettings* = object
     width*: int
@@ -203,10 +204,12 @@ proc populateDefaultMonitorSettings(this: Config, display: PDisplay) =
         "monospace:size=10:antialias=true",
         "NotoColorEmoji:size=10:antialias=true"
       ],
+      showIndicator: true,
       fgColor: 0xfce8c3,
       bgColor: 0x1c1b19,
       selectionColor: 0x519f50,
-      urgentColor: 0xef2f27
+      urgentColor: 0xef2f27,
+      hasTagsColor: 0xfce8c3
   )
 
   this.defaultMonitorSettings.layoutSettings = LayoutSettings(
@@ -404,6 +407,15 @@ proc populateBarSettings*(this: Config, barSettings: var BarSettings, settingsTa
     let barTransparency = settingsTable["barTransparency"]
     if barTransparency.kind == TomlValueKind.Int:
       barSettings.transparency = clamp(barTransparency.intVal, 0, 255).uint8
+
+  let hasTagsColor = this.loadHexValue(settingsTable, "barHasTagsColor")
+  if hasTagsColor != -1:
+    barSettings.hasTagsColor = hasTagsColor
+
+  if settingsTable.hasKey("barShowIndicator"):
+    let showIndicator = settingsTable["barShowIndicator"]
+    if showIndicator.kind == TomlValueKind.Bool:
+      barSettings.showIndicator = showIndicator.boolVal
 
   if settingsTable.hasKey("barHeight"):
     let barHeight = settingsTable["barHeight"]

--- a/src/nimdowpkg/statusbar.nim
+++ b/src/nimdowpkg/statusbar.nim
@@ -46,7 +46,7 @@ type
     visual: PVisual
     depth: int
     colormap: Colormap
-    fgColor*, bgColor*, selectionColor*, urgentColor*, hasTagsColor*: XftColor
+    fgColor*, bgColor*, selectionColor*, urgentColor*, hasWindowsColor*: XftColor
     area*: Area
     systrayWidth: int
     clickables: seq[tuple[start: int, stop: int, characters: seq[int]]]
@@ -269,7 +269,7 @@ proc freeAllColors(this: StatusBar) =
   this.freeColor(this.bgColor.unsafeAddr)
   this.freeColor(this.selectionColor.unsafeAddr)
   this.freeColor(this.urgentColor.unsafeAddr)
-  this.freeColor(this.hasTagsColor.unsafeAddr)
+  this.freeColor(this.hasWindowsColor.unsafeAddr)
 
 proc toRGB(hex: int): RGB =
   return (
@@ -293,7 +293,7 @@ proc configureColors(this: StatusBar) =
   this.configureColor(this.settings.bgColor, this.bgColor, this.settings.transparency)
   this.configureColor(this.settings.selectionColor, this.selectionColor)
   this.configureColor(this.settings.urgentColor, this.urgentColor)
-  this.configureColor(this.settings.hasTagsColor, this.hasTagsColor)
+  this.configureColor(this.settings.hasWindowsColor, this.hasWindowsColor)
 
 proc configureFont(this: StatusBar, fontString: string): PXftFont =
   result = XftFontOpenXlfd(this.display, this.screen, fontString)
@@ -754,7 +754,7 @@ proc renderTags(this: var StatusBar): int =
     if this.selectedTags.contains(tagID):
       fgColor = this.selectionColor
     elif not tagIsEmpty:
-      fgColor = this.hasTagsColor
+      fgColor = this.hasWindowsColor
 
     let text = tagSettings.displayString
     let stringLength = this.forEachCharacter(text, textXPos, fgColor)


### PR DESCRIPTION
Closes #231. This adds an option `barHasTagsColor` which sets the colour of a tag that has windows (just realized this is a very poor name, but don't have time to fix it right now). It also adds an option `barShowIndicator` which defaults to true and selects whether the indicator box is drawn or not.

Should probably choose a better name, and possibly also make it default to the same as the foreground color if no colour is explicitly set.