### PR TITLE
Fix for recent merge

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -54,6 +54,8 @@ exec = [
   barForegroundColor = "#f8f8f2"
   barSelectionColor = "#50fa7b"
   barUrgentColor = "#ff5555"
+  barHasWindowsColor = "#f5eodc"
+  barShowIndicator = false
   barTransparency = 255 # 0 to 255
   barFonts = [
     "monospace:size=10:antialias=true",

--- a/src/nimdowpkg/config/configloader.nim
+++ b/src/nimdowpkg/config/configloader.nim
@@ -45,7 +45,7 @@ type
     fonts*: seq[string]
     showIndicator*: bool
     # Hex values
-    fgColor*, bgColor*, selectionColor*, urgentColor*, hasWindowsColor: int
+    fgColor*, bgColor*, selectionColor*, urgentColor*, hasWindowsColor*: int
     transparency*: uint8
   ScratchpadSettings* = object
     width*: int


### PR DESCRIPTION
hasWindowsColor was locally declared in iconfigloader.nim which caused a build error, fixed the typo by adding an * to make it visible to statusbar.nim.

Added settings for color tags to default config.toml 